### PR TITLE
[codex] Clean up duplicated research helpers

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,8 +12,7 @@ import {
   ResearchGenerationError,
   ResearchTimeoutError,
   VendorResolutionError,
-  researchCompany,
-  researchCompanyStream
+  researchCompany
 } from './researchAgent.js';
 import { createMockReport } from './mockReport.js';
 import type {
@@ -41,9 +40,7 @@ app.get('/api/health', (_req, res) => {
 });
 
 app.post('/api/chat/test', (req, res) => {
-  const { companyName } = (req.body ?? {}) as Partial<ResearchRequest>;
-  const normalizedCompanyName =
-    typeof companyName === 'string' ? companyName.trim() : '';
+  const normalizedCompanyName = getNormalizedCompanyName(req);
 
   const response: ResearchResponse = {
     mode: 'test',
@@ -54,14 +51,9 @@ app.post('/api/chat/test', (req, res) => {
 });
 
 app.post('/api/chat', async (req, res) => {
-  const { companyName } = (req.body ?? {}) as Partial<ResearchRequest>;
-  const normalizedCompanyName =
-    typeof companyName === 'string' ? companyName.trim() : '';
+  const normalizedCompanyName = requireResearchTarget(req, res);
 
-  if (normalizedCompanyName.length < 2) {
-    res.status(400).json({
-      error: 'Enter a company or product name to research.'
-    });
+  if (!normalizedCompanyName) {
     return;
   }
 
@@ -84,14 +76,9 @@ app.post('/api/chat', async (req, res) => {
 });
 
 app.post('/api/chat/stream', async (req, res) => {
-  const { companyName } = (req.body ?? {}) as Partial<ResearchRequest>;
-  const normalizedCompanyName =
-    typeof companyName === 'string' ? companyName.trim() : '';
+  const normalizedCompanyName = requireResearchTarget(req, res);
 
-  if (normalizedCompanyName.length < 2) {
-    res.status(400).json({
-      error: 'Enter a company or product name to research.'
-    });
+  if (!normalizedCompanyName) {
     return;
   }
 
@@ -119,7 +106,7 @@ app.post('/api/chat/stream', async (req, res) => {
   sendEvent('ready', { ok: true });
 
   try {
-    const report = await researchCompanyStream(
+    const report = await researchCompany(
       normalizedCompanyName,
       (update: ResearchProgressUpdate) => {
         sendEvent('progress', update);
@@ -146,6 +133,26 @@ app.post('/api/chat/stream', async (req, res) => {
     }
   }
 });
+
+function getNormalizedCompanyName(req: express.Request) {
+  const { companyName } = (req.body ?? {}) as Partial<ResearchRequest>;
+
+  return typeof companyName === 'string' ? companyName.trim() : '';
+}
+
+function requireResearchTarget(req: express.Request, res: express.Response) {
+  const normalizedCompanyName = getNormalizedCompanyName(req);
+
+  if (normalizedCompanyName.length >= 2) {
+    return normalizedCompanyName;
+  }
+
+  res.status(400).json({
+    error: 'Enter a company or product name to research.'
+  });
+
+  return '';
+}
 
 function formatResearchError(error: unknown) {
   if (error instanceof MissingOpenAIKeyError) {

--- a/server/research/decisioning.ts
+++ b/server/research/decisioning.ts
@@ -1,7 +1,7 @@
 import { Agent, run } from '@openai/agents';
 import { z } from 'zod';
 import { normalizeHostname, type VendorResolution } from './vendorIntake.js';
-import { ResearchTimeoutError } from './errors.js';
+import { isAbortError, ResearchTimeoutError } from './errors.js';
 
 const evidenceItemSchema = z.object({
   title: z.string().min(1).max(160),
@@ -561,21 +561,6 @@ function deriveRecommendationFromStatuses(
   return 'green';
 }
 
-function isAbortError(error: unknown) {
-  const constructorName =
-    error && typeof error === 'object' && 'constructor' in error
-      ? (error.constructor as { name?: string }).name
-      : undefined;
-
-  return (
-    error instanceof Error &&
-    (error.name === 'AbortError' ||
-      error.name === 'TimeoutError' ||
-      error.name === 'APIUserAbortError' ||
-      constructorName === 'APIUserAbortError')
-  );
-}
-
 function normalizeEvidenceUrl(url: string, allowedDomains: string[]) {
   try {
     const parsed = new URL(url);
@@ -585,29 +570,31 @@ function normalizeEvidenceUrl(url: string, allowedDomains: string[]) {
       parsed.searchParams.delete(key)
     );
 
+    if (!isAllowedVendorHostname(parsed.hostname, allowedDomains)) {
+      return '';
+    }
+
     const normalized = `${parsed.origin}${parsed.pathname}${parsed.search ? parsed.search : ''}`.replace(
       /\/$/,
       ''
     );
 
-    return isAllowedVendorUrl(normalized, allowedDomains) ? normalized : '';
+    return normalized;
   } catch {
     return '';
   }
 }
 
-function isAllowedVendorUrl(url: string, allowedDomains: string[]) {
-  try {
-    const hostname = normalizeHostname(new URL(url).hostname);
+function isAllowedVendorHostname(hostname: string, allowedDomains: string[]) {
+  const normalizedHostname = normalizeHostname(hostname);
 
-    return allowedDomains.some((domain) => {
-      const normalizedDomain = normalizeHostname(domain);
-
-      return hostname === normalizedDomain || hostname.endsWith(`.${normalizedDomain}`);
-    });
-  } catch {
+  if (!normalizedHostname) {
     return false;
   }
+
+  return allowedDomains.some(
+    (domain) => normalizedHostname === domain || normalizedHostname.endsWith(`.${domain}`)
+  );
 }
 
 function evidenceTitleFromUrl(url: string) {

--- a/server/research/errors.ts
+++ b/server/research/errors.ts
@@ -39,3 +39,18 @@ export class VendorResolutionError extends Error {
     this.name = 'VendorResolutionError';
   }
 }
+
+export function isAbortError(error: unknown) {
+  const constructorName =
+    error && typeof error === 'object' && 'constructor' in error
+      ? (error.constructor as { name?: string }).name
+      : undefined;
+
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' ||
+      error.name === 'TimeoutError' ||
+      error.name === 'APIUserAbortError' ||
+      constructorName === 'APIUserAbortError')
+  );
+}

--- a/server/research/retrieval.ts
+++ b/server/research/retrieval.ts
@@ -9,6 +9,7 @@ import type { ResearchProgressStage, ResearchProgressUpdate } from '../../shared
 import { liveResearchStages } from '../../shared/contracts.js';
 import type { VendorResolution } from './vendorIntake.js';
 import {
+  isAbortError,
   ResearchGenerationError,
   ResearchTimeoutError
 } from './errors.js';
@@ -277,22 +278,6 @@ function updateProgressFromStreamEvent(
 
   return nextMemoText;
 }
-
-function isAbortError(error: unknown) {
-  const constructorName =
-    error && typeof error === 'object' && 'constructor' in error
-      ? (error.constructor as { name?: string }).name
-      : undefined;
-
-  return (
-    error instanceof Error &&
-    (error.name === 'AbortError' ||
-      error.name === 'TimeoutError' ||
-      error.name === 'APIUserAbortError' ||
-      constructorName === 'APIUserAbortError')
-  );
-}
-
 function isRetryableModelError(error: unknown) {
   return (
     error instanceof ModelBehaviorError ||

--- a/server/research/vendorIntake.ts
+++ b/server/research/vendorIntake.ts
@@ -2,6 +2,7 @@ import { Agent, run } from '@openai/agents';
 import { z } from 'zod';
 import {
   InvalidVendorInputError,
+  isAbortError,
   ResearchTimeoutError,
   VendorResolutionError
 } from './errors.js';
@@ -192,19 +193,4 @@ ${JSON.stringify({ companyName })}
 
 Return the canonical vendor name, official vendor-controlled domains, confidence, alternatives, and short rationale.
 `.trim();
-}
-
-function isAbortError(error: unknown) {
-  const constructorName =
-    error && typeof error === 'object' && 'constructor' in error
-      ? (error.constructor as { name?: string }).name
-      : undefined;
-
-  return (
-    error instanceof Error &&
-    (error.name === 'AbortError' ||
-      error.name === 'TimeoutError' ||
-      error.name === 'APIUserAbortError' ||
-      constructorName === 'APIUserAbortError')
-  );
 }

--- a/server/researchAgent.ts
+++ b/server/researchAgent.ts
@@ -32,18 +32,10 @@ function getResearchTimeoutMs() {
   return parsed;
 }
 
-export async function researchCompany(companyName: string) {
-  return runResearchWorkflow(companyName);
-}
-
-export async function researchCompanyStream(
+export async function researchCompany(
   companyName: string,
   onProgress?: ResearchProgressListener
 ) {
-  if (!process.env.OPENAI_API_KEY) {
-    throw new MissingOpenAIKeyError();
-  }
-
   return runResearchWorkflow(companyName, onProgress);
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import type {
   EnterpriseReadinessReport,
   GuardrailAssessment,
@@ -15,6 +15,10 @@ const isTestMode =
   new URLSearchParams(window.location.search).get('mode') === 'test';
 const conversationStorageKey = `archreviewagent.conversations.${isTestMode ? 'test' : 'live'}`;
 const maxStoredConversations = 40;
+const dateFormatter = new Intl.DateTimeFormat('en-GB', {
+  dateStyle: 'medium',
+  timeStyle: 'short'
+});
 
 type Message = {
   id: string;
@@ -65,7 +69,7 @@ export default function App() {
   const [pendingAssistantMessage, setPendingAssistantMessage] =
     useState<PendingAssistantMessage | null>(null);
   const [, startTransition] = useTransition();
-  const deferredCompanyName = useDeferredValue(companyName.trim());
+  const trimmedCompanyName = companyName.trim();
   const activeConversation = findActiveConversation(
     conversationState.conversations,
     conversationState.activeConversationId
@@ -257,7 +261,7 @@ export default function App() {
         <div className="signal-block">
           <p className="section-label">Current query</p>
           <p className="live-query">
-            {deferredCompanyName ||
+            {trimmedCompanyName ||
               (isConversationEmpty(activeConversation)
                 ? 'Waiting for a vendor name'
                 : activeConversationTitle)}
@@ -688,10 +692,7 @@ function formatDate(value: string) {
     return value;
   }
 
-  return new Intl.DateTimeFormat('en-GB', {
-    dateStyle: 'medium',
-    timeStyle: 'short'
-  }).format(parsed);
+  return dateFormatter.format(parsed);
 }
 
 function loadConversationState(): ConversationState {
@@ -745,7 +746,7 @@ function saveConversationState(state: ConversationState) {
       conversationStorageKey,
       JSON.stringify({
         ...state,
-        conversations: sortConversations(state.conversations).slice(0, maxStoredConversations)
+        conversations: state.conversations.slice(0, maxStoredConversations)
       })
     );
   } catch {


### PR DESCRIPTION
## What changed
- consolidated duplicated abort-error detection into a shared backend helper
- simplified backend request validation and research entrypoints
- removed redundant URL/domain normalization work in decisioning
- cleaned frontend rendering hot paths by hoisting the date formatter, removing unnecessary deferred state, and avoiding redundant conversation sorting

## Why
These were the high-confidence cleanup items from the review pass: duplicated helpers, repeated validation logic, and small but real render/hot-path inefficiencies.

## Impact
- lower maintenance risk in the research backend
- less duplicated request-handling logic
- slightly cheaper frontend sidebar/history rendering
- no product behavior change intended

## Validation
- `npm run build`
- `npm run test:server`