### PR TITLE
Persist production trace artifacts for shadow grading

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,16 @@ If `DATABASE_URL` is configured, the backend will:
 
 - cache resolved vendor identities
 - cache accepted research reports and their evidence metadata
+- persist per-run trace artifacts for offline shadow grading
 - reuse fresh accepted reports on repeated lookups for more stable results
 - trigger one background refresh on cache hits, then compare the refreshed candidate against the accepted baseline before promotion
+
+To inspect stored research traces locally:
+
+```bash
+npm run traces:inspect -- --limit 5
+npm run traces:inspect -- --run-id <run_id>
+```
 
 In production:
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:client": "vite --host 0.0.0.0",
     "dev:server": "tsx watch server/index.ts",
     "db:migrate": "node --import tsx server/db/migrate.ts",
+    "traces:inspect": "node --import tsx server/db/inspectResearchRunTraces.ts",
     "build": "vite build && tsc -p tsconfig.server.json",
     "start": "node dist-server/server/index.js",
     "test:server": "node --import tsx --test server/**/*.test.ts",

--- a/server/db/inspectResearchRunTraces.ts
+++ b/server/db/inspectResearchRunTraces.ts
@@ -1,0 +1,52 @@
+import 'dotenv/config';
+
+import process from 'node:process';
+import {
+  listResearchRunTraces,
+  loadResearchRunTrace
+} from './researchRunTraceRepository.js';
+import { closeDatabasePool } from './client.js';
+import { getDatabaseUrl } from './config.js';
+
+async function main() {
+  if (!getDatabaseUrl()) {
+    throw new Error('DATABASE_URL must be set before inspecting stored traces.');
+  }
+
+  const args = process.argv.slice(2);
+  const runId = readFlag(args, '--run-id');
+  const subjectName = readFlag(args, '--subject');
+  const limitValue = readFlag(args, '--limit');
+
+  const payload = runId
+    ? await loadResearchRunTrace(runId)
+    : await listResearchRunTraces({
+        subjectName,
+        limit: limitValue ? Number(limitValue) : undefined
+      });
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+
+  if (!payload || (Array.isArray(payload) && payload.length === 0)) {
+    process.exitCode = 1;
+  }
+}
+
+function readFlag(args: string[], flag: string) {
+  const index = args.indexOf(flag);
+
+  if (index === -1) {
+    return undefined;
+  }
+
+  return args[index + 1];
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDatabasePool();
+  });

--- a/server/db/migrations/002_research_run_traces.sql
+++ b/server/db/migrations/002_research_run_traces.sql
@@ -1,0 +1,33 @@
+create table if not exists research_run_traces (
+  run_id text primary key,
+  requested_subject_name text not null,
+  subject_key text,
+  canonical_subject_name text,
+  canonical_vendor_name text,
+  official_domains jsonb not null default '[]'::jsonb,
+  outcome text not null check (outcome in ('succeeded', 'failed')),
+  recommendation text check (recommendation in ('green', 'yellow', 'red')),
+  eu_status text check (eu_status in ('supported', 'partial', 'unsupported', 'unknown')),
+  enterprise_status text check (enterprise_status in ('supported', 'partial', 'unsupported', 'unknown')),
+  cache_path jsonb not null default '{}'::jsonb,
+  phase_timings jsonb not null default '{}'::jsonb,
+  memo_length integer not null default 0,
+  promotion_result jsonb,
+  bundle_id text,
+  baseline_bundle_id text,
+  error_phase text,
+  error_class text,
+  error_name text,
+  error_message text,
+  trace jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists research_run_traces_created_idx
+  on research_run_traces (created_at desc);
+
+create index if not exists research_run_traces_subject_idx
+  on research_run_traces (subject_key, created_at desc);
+
+create index if not exists research_run_traces_outcome_idx
+  on research_run_traces (outcome, created_at desc);

--- a/server/db/migrations/002_research_run_traces.sql
+++ b/server/db/migrations/002_research_run_traces.sql
@@ -1,5 +1,6 @@
 create table if not exists research_run_traces (
-  run_id text primary key,
+  trace_id bigserial primary key,
+  run_id text not null,
   requested_subject_name text not null,
   subject_key text,
   canonical_subject_name text,
@@ -26,8 +27,11 @@ create table if not exists research_run_traces (
 create index if not exists research_run_traces_created_idx
   on research_run_traces (created_at desc);
 
+create index if not exists research_run_traces_run_id_idx
+  on research_run_traces (run_id, created_at desc, trace_id desc);
+
 create index if not exists research_run_traces_subject_idx
-  on research_run_traces (subject_key, created_at desc);
+  on research_run_traces (subject_key, created_at desc, trace_id desc);
 
 create index if not exists research_run_traces_outcome_idx
-  on research_run_traces (outcome, created_at desc);
+  on research_run_traces (outcome, created_at desc, trace_id desc);

--- a/server/db/migrations/003_append_only_research_run_traces.sql
+++ b/server/db/migrations/003_append_only_research_run_traces.sql
@@ -1,0 +1,35 @@
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_name = 'research_run_traces'
+      and column_name = 'trace_id'
+  ) then
+    return;
+  end if;
+
+  alter table research_run_traces
+    add column trace_id bigserial;
+
+  alter table research_run_traces
+    drop constraint research_run_traces_pkey;
+
+  alter table research_run_traces
+    add constraint research_run_traces_pkey primary key (trace_id);
+
+  alter table research_run_traces
+    alter column run_id set not null;
+end
+$$;
+
+create index if not exists research_run_traces_run_id_idx
+  on research_run_traces (run_id, created_at desc, trace_id desc);
+
+drop index if exists research_run_traces_subject_idx;
+create index if not exists research_run_traces_subject_idx
+  on research_run_traces (subject_key, created_at desc, trace_id desc);
+
+drop index if exists research_run_traces_outcome_idx;
+create index if not exists research_run_traces_outcome_idx
+  on research_run_traces (outcome, created_at desc, trace_id desc);

--- a/server/db/researchRunTraceRepository.ts
+++ b/server/db/researchRunTraceRepository.ts
@@ -5,6 +5,7 @@ import { normalizeSubjectCacheKey } from './researchCacheRepository.js';
 import { queryDatabase } from './client.js';
 
 type ResearchRunTraceRow = {
+  trace_id?: number;
   run_id: string;
   requested_subject_name: string;
   subject_key: string | null;
@@ -87,27 +88,6 @@ export async function storeResearchRunTrace(trace: ResearchRunTracePayload) {
         $1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11::jsonb, $12::jsonb,
         $13, $14::jsonb, $15, $16, $17, $18, $19, $20, $21::jsonb
       )
-      on conflict (run_id) do update set
-        requested_subject_name = excluded.requested_subject_name,
-        subject_key = excluded.subject_key,
-        canonical_subject_name = excluded.canonical_subject_name,
-        canonical_vendor_name = excluded.canonical_vendor_name,
-        official_domains = excluded.official_domains,
-        outcome = excluded.outcome,
-        recommendation = excluded.recommendation,
-        eu_status = excluded.eu_status,
-        enterprise_status = excluded.enterprise_status,
-        cache_path = excluded.cache_path,
-        phase_timings = excluded.phase_timings,
-        memo_length = excluded.memo_length,
-        promotion_result = excluded.promotion_result,
-        bundle_id = excluded.bundle_id,
-        baseline_bundle_id = excluded.baseline_bundle_id,
-        error_phase = excluded.error_phase,
-        error_class = excluded.error_class,
-        error_name = excluded.error_name,
-        error_message = excluded.error_message,
-        trace = excluded.trace
     `,
     [
       trace.runId,
@@ -143,6 +123,7 @@ export async function loadResearchRunTrace(runId: string) {
   const result = await queryDatabase<ResearchRunTraceRow>(
     `
       select
+        trace_id,
         run_id,
         requested_subject_name,
         subject_key,
@@ -167,6 +148,7 @@ export async function loadResearchRunTrace(runId: string) {
         created_at
       from research_run_traces
       where run_id = $1
+      order by created_at desc, trace_id desc
       limit 1
     `,
     [runId]
@@ -199,6 +181,7 @@ export async function listResearchRunTraces(options: {
   const result = await queryDatabase<ResearchRunTraceRow>(
     `
       select
+        trace_id,
         run_id,
         requested_subject_name,
         subject_key,
@@ -223,7 +206,7 @@ export async function listResearchRunTraces(options: {
         created_at
       from research_run_traces
       ${whereClause}
-      order by created_at desc
+      order by created_at desc, trace_id desc
       limit ${limitPlaceholder}
     `,
     values

--- a/server/db/researchRunTraceRepository.ts
+++ b/server/db/researchRunTraceRepository.ts
@@ -1,0 +1,272 @@
+import type { ReadinessStatus, RecommendationLevel } from '../../shared/contracts.js';
+import type { ResearchRunTracePayload } from '../research/traceArtifacts.js';
+import { isDatabaseConfigured } from './config.js';
+import { normalizeSubjectCacheKey } from './researchCacheRepository.js';
+import { queryDatabase } from './client.js';
+
+type ResearchRunTraceRow = {
+  run_id: string;
+  requested_subject_name: string;
+  subject_key: string | null;
+  canonical_subject_name: string | null;
+  canonical_vendor_name: string | null;
+  official_domains: string[];
+  outcome: 'succeeded' | 'failed';
+  recommendation: RecommendationLevel | null;
+  eu_status: ReadinessStatus | null;
+  enterprise_status: ReadinessStatus | null;
+  cache_path: Record<string, unknown>;
+  phase_timings: Record<string, number>;
+  memo_length: number;
+  promotion_result: Record<string, unknown> | null;
+  bundle_id: string | null;
+  baseline_bundle_id: string | null;
+  error_phase: string | null;
+  error_class: string | null;
+  error_name: string | null;
+  error_message: string | null;
+  trace: ResearchRunTracePayload;
+  created_at: string;
+};
+
+export type StoredResearchRunTrace = {
+  runId: string;
+  requestedSubjectName: string;
+  subjectKey: string | null;
+  canonicalSubjectName: string | null;
+  canonicalVendorName: string | null;
+  officialDomains: string[];
+  outcome: 'succeeded' | 'failed';
+  recommendation: RecommendationLevel | null;
+  euStatus: ReadinessStatus | null;
+  enterpriseStatus: ReadinessStatus | null;
+  cachePath: Record<string, unknown>;
+  phaseTimings: Record<string, number>;
+  memoLength: number;
+  promotionResult: Record<string, unknown> | null;
+  bundleId: string | null;
+  baselineBundleId: string | null;
+  errorPhase: string | null;
+  errorClass: string | null;
+  errorName: string | null;
+  errorMessage: string | null;
+  trace: ResearchRunTracePayload;
+  createdAt: string;
+};
+
+export async function storeResearchRunTrace(trace: ResearchRunTracePayload) {
+  if (!isDatabaseConfigured()) {
+    return;
+  }
+
+  await queryDatabase(
+    `
+      insert into research_run_traces (
+        run_id,
+        requested_subject_name,
+        subject_key,
+        canonical_subject_name,
+        canonical_vendor_name,
+        official_domains,
+        outcome,
+        recommendation,
+        eu_status,
+        enterprise_status,
+        cache_path,
+        phase_timings,
+        memo_length,
+        promotion_result,
+        bundle_id,
+        baseline_bundle_id,
+        error_phase,
+        error_class,
+        error_name,
+        error_message,
+        trace
+      ) values (
+        $1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11::jsonb, $12::jsonb,
+        $13, $14::jsonb, $15, $16, $17, $18, $19, $20, $21::jsonb
+      )
+      on conflict (run_id) do update set
+        requested_subject_name = excluded.requested_subject_name,
+        subject_key = excluded.subject_key,
+        canonical_subject_name = excluded.canonical_subject_name,
+        canonical_vendor_name = excluded.canonical_vendor_name,
+        official_domains = excluded.official_domains,
+        outcome = excluded.outcome,
+        recommendation = excluded.recommendation,
+        eu_status = excluded.eu_status,
+        enterprise_status = excluded.enterprise_status,
+        cache_path = excluded.cache_path,
+        phase_timings = excluded.phase_timings,
+        memo_length = excluded.memo_length,
+        promotion_result = excluded.promotion_result,
+        bundle_id = excluded.bundle_id,
+        baseline_bundle_id = excluded.baseline_bundle_id,
+        error_phase = excluded.error_phase,
+        error_class = excluded.error_class,
+        error_name = excluded.error_name,
+        error_message = excluded.error_message,
+        trace = excluded.trace
+    `,
+    [
+      trace.runId,
+      trace.requestedSubjectName,
+      trace.subjectKey,
+      trace.canonicalSubjectName,
+      trace.canonicalVendorName,
+      JSON.stringify(trace.officialDomains),
+      trace.outcome,
+      trace.recommendation,
+      trace.guardrails.euDataResidency?.status ?? null,
+      trace.guardrails.enterpriseDeployment?.status ?? null,
+      JSON.stringify(trace.cachePath),
+      JSON.stringify(trace.phaseTimings),
+      trace.memoLength,
+      JSON.stringify(trace.promotionResult),
+      trace.bundleId,
+      trace.baselineBundleId,
+      trace.error?.phase ?? null,
+      trace.error?.errorClass ?? null,
+      trace.error?.errorName ?? null,
+      trace.error?.errorMessage ?? null,
+      JSON.stringify(trace)
+    ]
+  );
+}
+
+export async function loadResearchRunTrace(runId: string) {
+  if (!isDatabaseConfigured()) {
+    return null;
+  }
+
+  const result = await queryDatabase<ResearchRunTraceRow>(
+    `
+      select
+        run_id,
+        requested_subject_name,
+        subject_key,
+        canonical_subject_name,
+        canonical_vendor_name,
+        official_domains,
+        outcome,
+        recommendation,
+        eu_status,
+        enterprise_status,
+        cache_path,
+        phase_timings,
+        memo_length,
+        promotion_result,
+        bundle_id,
+        baseline_bundle_id,
+        error_phase,
+        error_class,
+        error_name,
+        error_message,
+        trace,
+        created_at
+      from research_run_traces
+      where run_id = $1
+      limit 1
+    `,
+    [runId]
+  );
+
+  return mapResearchRunTraceRow(result.rows[0] ?? null);
+}
+
+export async function listResearchRunTraces(options: {
+  subjectName?: string;
+  limit?: number;
+} = {}) {
+  if (!isDatabaseConfigured()) {
+    return [];
+  }
+
+  const values: unknown[] = [];
+  const predicates: string[] = [];
+
+  if (options.subjectName?.trim()) {
+    values.push(normalizeSubjectCacheKey(options.subjectName));
+    predicates.push(`subject_key = $${values.length}`);
+  }
+
+  values.push(normalizeTraceListLimit(options.limit));
+  const limitPlaceholder = `$${values.length}`;
+  const whereClause =
+    predicates.length > 0 ? `where ${predicates.join(' and ')}` : '';
+
+  const result = await queryDatabase<ResearchRunTraceRow>(
+    `
+      select
+        run_id,
+        requested_subject_name,
+        subject_key,
+        canonical_subject_name,
+        canonical_vendor_name,
+        official_domains,
+        outcome,
+        recommendation,
+        eu_status,
+        enterprise_status,
+        cache_path,
+        phase_timings,
+        memo_length,
+        promotion_result,
+        bundle_id,
+        baseline_bundle_id,
+        error_phase,
+        error_class,
+        error_name,
+        error_message,
+        trace,
+        created_at
+      from research_run_traces
+      ${whereClause}
+      order by created_at desc
+      limit ${limitPlaceholder}
+    `,
+    values
+  );
+
+  return result.rows.map((row) => mapResearchRunTraceRow(row)!);
+}
+
+function normalizeTraceListLimit(limit: number | undefined) {
+  if (!Number.isFinite(limit) || (limit ?? 0) <= 0) {
+    return 10;
+  }
+
+  return Math.min(Math.trunc(limit ?? 10), 100);
+}
+
+function mapResearchRunTraceRow(row: ResearchRunTraceRow | null): StoredResearchRunTrace | null {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    runId: row.run_id,
+    requestedSubjectName: row.requested_subject_name,
+    subjectKey: row.subject_key,
+    canonicalSubjectName: row.canonical_subject_name,
+    canonicalVendorName: row.canonical_vendor_name,
+    officialDomains: row.official_domains,
+    outcome: row.outcome,
+    recommendation: row.recommendation,
+    euStatus: row.eu_status,
+    enterpriseStatus: row.enterprise_status,
+    cachePath: row.cache_path,
+    phaseTimings: row.phase_timings,
+    memoLength: row.memo_length,
+    promotionResult: row.promotion_result,
+    bundleId: row.bundle_id,
+    baselineBundleId: row.baseline_bundle_id,
+    errorPhase: row.error_phase,
+    errorClass: row.error_class,
+    errorName: row.error_name,
+    errorMessage: row.error_message,
+    trace: row.trace,
+    createdAt: row.created_at
+  };
+}

--- a/server/research/traceArtifacts.test.ts
+++ b/server/research/traceArtifacts.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildResearchRunTracePayload } from './traceArtifacts.js';
+import type { EnterpriseReadinessReport } from '../../shared/contracts.js';
+
+const sampleReport: EnterpriseReadinessReport = {
+  companyName: 'Microsoft Fabric',
+  researchedAt: '2026-04-08T21:00:00.000Z',
+  overview: 'Analytics product.',
+  executiveSummary: 'Summary.',
+  recommendation: 'yellow',
+  deploymentVerdict: 'Verdict.',
+  guardrails: {
+    euDataResidency: {
+      status: 'partial',
+      confidence: 'medium',
+      summary: 'EU summary.',
+      risks: ['Risk'],
+      evidence: [
+        {
+          title: 'EU evidence',
+          url: 'https://example.com/eu',
+          publisher: 'Example',
+          finding: 'EU finding.',
+          sourceType: 'primary'
+        }
+      ]
+    },
+    enterpriseDeployment: {
+      status: 'supported',
+      confidence: 'high',
+      summary: 'Deployment summary.',
+      risks: ['Risk'],
+      evidence: [
+        {
+          title: 'Deployment evidence',
+          url: 'https://example.com/deploy',
+          publisher: 'Example',
+          finding: 'Deployment finding.',
+          sourceType: 'primary'
+        }
+      ]
+    }
+  },
+  unansweredQuestions: ['Question'],
+  nextSteps: ['Step']
+};
+
+test('buildResearchRunTracePayload captures success fields needed for shadow grading', () => {
+  const trace = buildResearchRunTracePayload({
+    runId: 'abc12345',
+    requestedSubjectName: 'Microsoft Fabric',
+    subjectKey: 'microsoft',
+    canonicalSubjectName: 'Microsoft Fabric',
+    canonicalVendorName: 'Microsoft',
+    officialDomains: ['microsoft.com', 'fabric.microsoft.com'],
+    outcome: 'succeeded',
+    cachePath: {
+      resolutionSource: 'cache',
+      acceptedReportCache: 'hit'
+    },
+    phaseTimings: {
+      resolutionCompletedMs: 22,
+      cacheHitMs: 31,
+      completedMs: 31
+    },
+    memoLength: 1800,
+    report: sampleReport,
+    promotionResult: {
+      promotedCandidate: false,
+      reason: 'accepted_cache_hit',
+      detail: 'bundle_1'
+    },
+    bundleId: 'bundle_1',
+    baselineBundleId: 'bundle_1',
+    backgroundRefresh: true,
+    forceRefresh: false,
+    streamed: true
+  });
+
+  assert.equal(trace.recommendation, 'yellow');
+  assert.equal(trace.guardrails.euDataResidency?.status, 'partial');
+  assert.equal(trace.guardrails.enterpriseDeployment?.evidenceCount, 1);
+  assert.equal(trace.promotionResult?.reason, 'accepted_cache_hit');
+  assert.equal(trace.error, null);
+});
+
+test('buildResearchRunTracePayload captures failure fields without a report', () => {
+  const trace = buildResearchRunTracePayload({
+    runId: 'def67890',
+    requestedSubjectName: 'a',
+    outcome: 'failed',
+    memoLength: 0,
+    phaseTimings: {
+      failedMs: 12
+    },
+    error: {
+      phase: 'intake',
+      errorClass: 'InvalidVendorInputError',
+      errorName: 'InvalidVendorInputError',
+      errorMessage: 'Enter a company or product name to research.'
+    }
+  });
+
+  assert.equal(trace.report, null);
+  assert.equal(trace.recommendation, null);
+  assert.equal(trace.error?.phase, 'intake');
+  assert.equal(trace.phaseTimings.failedMs, 12);
+});

--- a/server/research/traceArtifacts.ts
+++ b/server/research/traceArtifacts.ts
@@ -1,0 +1,151 @@
+import type {
+  ConfidenceLevel,
+  EnterpriseReadinessReport,
+  RecommendationLevel,
+  ReadinessStatus
+} from '../../shared/contracts.js';
+
+export type GuardrailTraceSummary = {
+  status: ReadinessStatus;
+  confidence: ConfidenceLevel;
+  evidenceCount: number;
+};
+
+export type ResearchRunTracePayload = {
+  traceVersion: 1;
+  runId: string;
+  requestedSubjectName: string;
+  subjectKey: string | null;
+  canonicalSubjectName: string | null;
+  canonicalVendorName: string | null;
+  officialDomains: string[];
+  outcome: 'succeeded' | 'failed';
+  cachePath: Record<string, unknown>;
+  phaseTimings: Record<string, number>;
+  memoLength: number;
+  recommendation: RecommendationLevel | null;
+  guardrails: {
+    euDataResidency: GuardrailTraceSummary | null;
+    enterpriseDeployment: GuardrailTraceSummary | null;
+  };
+  promotionResult: {
+    promotedCandidate: boolean;
+    reason: string;
+    detail: string | null;
+  } | null;
+  bundleId: string | null;
+  baselineBundleId: string | null;
+  error: {
+    phase: string;
+    errorClass: string;
+    errorName: string;
+    errorMessage: string;
+  } | null;
+  report: EnterpriseReadinessReport | null;
+  context: {
+    backgroundRefresh: boolean;
+    forceRefresh: boolean;
+    streamed: boolean;
+  };
+};
+
+export function buildResearchRunTracePayload(input: {
+  runId: string;
+  requestedSubjectName: string;
+  subjectKey?: string | null;
+  canonicalSubjectName?: string | null;
+  canonicalVendorName?: string | null;
+  officialDomains?: string[] | null;
+  outcome: 'succeeded' | 'failed';
+  cachePath?: Record<string, unknown>;
+  phaseTimings?: Record<string, number | undefined>;
+  memoLength?: number;
+  report?: EnterpriseReadinessReport | null;
+  promotionResult?: {
+    promotedCandidate: boolean;
+    reason: string;
+    detail?: string | null;
+  } | null;
+  bundleId?: string | null;
+  baselineBundleId?: string | null;
+  error?: {
+    phase: string;
+    errorClass: string;
+    errorName: string;
+    errorMessage: string;
+  } | null;
+  backgroundRefresh?: boolean;
+  forceRefresh?: boolean;
+  streamed?: boolean;
+}): ResearchRunTracePayload {
+  const report = input.report ?? null;
+
+  return {
+    traceVersion: 1,
+    runId: input.runId,
+    requestedSubjectName: input.requestedSubjectName,
+    subjectKey: input.subjectKey ?? null,
+    canonicalSubjectName: input.canonicalSubjectName ?? report?.companyName ?? null,
+    canonicalVendorName: input.canonicalVendorName ?? null,
+    officialDomains: input.officialDomains ?? [],
+    outcome: input.outcome,
+    cachePath: input.cachePath ?? {},
+    phaseTimings: normalizePhaseTimings(input.phaseTimings),
+    memoLength: Math.max(0, input.memoLength ?? 0),
+    recommendation: report?.recommendation ?? null,
+    guardrails: summarizeGuardrails(report),
+    promotionResult: input.promotionResult
+      ? {
+          promotedCandidate: input.promotionResult.promotedCandidate,
+          reason: input.promotionResult.reason,
+          detail: input.promotionResult.detail ?? null
+        }
+      : null,
+    bundleId: input.bundleId ?? null,
+    baselineBundleId: input.baselineBundleId ?? null,
+    error: input.error ?? null,
+    report,
+    context: {
+      backgroundRefresh: Boolean(input.backgroundRefresh),
+      forceRefresh: Boolean(input.forceRefresh),
+      streamed: Boolean(input.streamed)
+    }
+  };
+}
+
+function normalizePhaseTimings(
+  phaseTimings: Record<string, number | undefined> | undefined
+) {
+  if (!phaseTimings) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(phaseTimings).filter(
+      (entry): entry is [string, number] =>
+        Number.isFinite(entry[1]) && (entry[1] ?? 0) >= 0
+    )
+  );
+}
+
+function summarizeGuardrails(report: EnterpriseReadinessReport | null) {
+  if (!report) {
+    return {
+      euDataResidency: null,
+      enterpriseDeployment: null
+    };
+  }
+
+  return {
+    euDataResidency: {
+      status: report.guardrails.euDataResidency.status,
+      confidence: report.guardrails.euDataResidency.confidence,
+      evidenceCount: report.guardrails.euDataResidency.evidence.length
+    },
+    enterpriseDeployment: {
+      status: report.guardrails.enterpriseDeployment.status,
+      confidence: report.guardrails.enterpriseDeployment.confidence,
+      evidenceCount: report.guardrails.enterpriseDeployment.evidence.length
+    }
+  };
+}

--- a/server/researchAgent.ts
+++ b/server/researchAgent.ts
@@ -34,6 +34,8 @@ import {
   storeResearchArtifacts,
   storeVendorResolution
 } from './db/researchCacheRepository.js';
+import { storeResearchRunTrace } from './db/researchRunTraceRepository.js';
+import { buildResearchRunTracePayload } from './research/traceArtifacts.js';
 type ResearchProgressListener = (update: ResearchProgressUpdate) => void;
 type ResearchWorkflowOptions = {
   onProgress?: ResearchProgressListener;
@@ -106,6 +108,14 @@ async function runResearchWorkflow(
   let baselineSnapshot:
     | Awaited<ReturnType<typeof loadLatestAcceptedReportSnapshot>>
     | undefined;
+  const phaseTimings: Record<string, number> = {};
+  const cachePath: Record<string, unknown> = {
+    resolutionSource,
+    acceptedReportCache: options.skipAcceptedReportCache ? 'skipped' : 'miss',
+    backgroundRefresh: Boolean(options.backgroundRefresh),
+    forceRefresh: Boolean(options.forceRefresh),
+    streamed: Boolean(options.onProgress)
+  };
 
   try {
     companyName = validateVendorInput(rawCompanyName);
@@ -143,6 +153,8 @@ async function runResearchWorkflow(
       resolutionSource,
       elapsedMs: Date.now() - startedAt
     });
+    phaseTimings.resolutionCompletedMs = Date.now() - startedAt;
+    cachePath.resolutionSource = resolutionSource;
 
     const cachedReport = options.skipAcceptedReportCache
       ? null
@@ -162,16 +174,46 @@ async function runResearchWorkflow(
         bundleId: cachedReport.bundleId,
         cachedAt: cachedReport.fetchedAt
       });
+      phaseTimings.cacheHitMs = Date.now() - startedAt;
+      phaseTimings.completedMs = Date.now() - startedAt;
+      cachePath.acceptedReportCache = 'hit';
+      cachePath.bundleId = cachedReport.bundleId;
       maybeStartBackgroundRefresh(runId, companyName, acceptedSubjectKey, resolution, cachedReport);
+      await tryStoreResearchRunTrace(runId, buildResearchRunTracePayload({
+        runId,
+        requestedSubjectName: companyName,
+        subjectKey: acceptedSubjectKey,
+        canonicalSubjectName: cachedReport.report.companyName,
+        canonicalVendorName: resolution.canonicalName,
+        officialDomains: resolution.officialDomains,
+        outcome: 'succeeded',
+        cachePath,
+        phaseTimings,
+        memoLength: cachedReport.memo.length,
+        report: cachedReport.report,
+        promotionResult: {
+          promotedCandidate: false,
+          reason: 'accepted_cache_hit',
+          detail: cachedReport.bundleId
+        },
+        bundleId: cachedReport.bundleId,
+        baselineBundleId: cachedReport.bundleId,
+        backgroundRefresh: options.backgroundRefresh,
+        forceRefresh: options.forceRefresh,
+        streamed: Boolean(options.onProgress)
+      }));
 
       return cachedReport.report;
     }
+
+    cachePath.acceptedReportCache = options.skipAcceptedReportCache ? 'skipped' : 'miss';
 
     baselineSnapshot = await tryLoadLatestAcceptedReportSnapshot(
       runId,
       companyName,
       acceptedSubjectKey
     );
+    cachePath.baselineBundleId = baselineSnapshot?.bundleId ?? null;
 
     phase = 'retrieval';
     memo = await generateResearchMemo(
@@ -191,6 +233,7 @@ async function runResearchWorkflow(
       hasDeploymentSection: /enterprise deployment/i.test(memo),
       elapsedMs: Date.now() - startedAt
     });
+    phaseTimings.memoGeneratedMs = Date.now() - startedAt;
 
     phase = 'decision';
     decision = await buildDecisionFromMemo(
@@ -215,6 +258,7 @@ async function runResearchWorkflow(
       preliminaryVerdictLength: decision.preliminaryVerdict.length,
       elapsedMs: Date.now() - startedAt
     });
+    phaseTimings.decisionBuiltMs = Date.now() - startedAt;
 
     phase = 'presentation';
     const candidateReport = presentDecision(decision);
@@ -230,6 +274,8 @@ async function runResearchWorkflow(
       promotionReason: promotionDecision.reason,
       promotionDetail: promotionDecision.detail
     });
+    cachePath.baselineBundleId = baselineSnapshot?.bundleId ?? null;
+    cachePath.promotedCandidate = promotionDecision.promoteCandidate;
     const storedArtifacts = await tryStoreResearchArtifacts(runId, {
       subjectKey: acceptedSubjectKey,
       requestedSubjectName: companyName,
@@ -257,6 +303,34 @@ async function runResearchWorkflow(
       backgroundRefresh: Boolean(options.backgroundRefresh),
       elapsedMs: Date.now() - startedAt
     });
+    phaseTimings.reportPresentedMs = Date.now() - startedAt;
+    phaseTimings.completedMs = Date.now() - startedAt;
+    cachePath.bundleId = storedArtifacts?.bundleId ?? null;
+    cachePath.retainedBaselineBundleId =
+      promotionDecision.promoteCandidate ? null : baselineSnapshot?.bundleId ?? null;
+    await tryStoreResearchRunTrace(runId, buildResearchRunTracePayload({
+      runId,
+      requestedSubjectName: companyName,
+      subjectKey: acceptedSubjectKey,
+      canonicalSubjectName: report.companyName,
+      canonicalVendorName: resolution.canonicalName,
+      officialDomains: resolution.officialDomains,
+      outcome: 'succeeded',
+      cachePath,
+      phaseTimings,
+      memoLength: memo.length,
+      report,
+      promotionResult: {
+        promotedCandidate: promotionDecision.promoteCandidate,
+        reason: promotionDecision.reason,
+        detail: promotionDecision.detail ?? null
+      },
+      bundleId: storedArtifacts?.bundleId ?? null,
+      baselineBundleId: baselineSnapshot?.bundleId ?? null,
+      backgroundRefresh: options.backgroundRefresh,
+      forceRefresh: options.forceRefresh,
+      streamed: Boolean(options.onProgress)
+    }));
 
     return report;
   } catch (error) {
@@ -277,6 +351,33 @@ async function runResearchWorkflow(
       elapsedMs: Date.now() - startedAt,
       ...describeError(error)
     });
+    phaseTimings.failedMs = Date.now() - startedAt;
+    await tryStoreResearchRunTrace(runId, buildResearchRunTracePayload({
+      runId,
+      requestedSubjectName:
+        phase === 'intake'
+          ? rawCompanyName.trim() || inputSummary.preview
+          : companyName,
+      subjectKey: acceptedSubjectKey || null,
+      canonicalSubjectName: decision?.companyName ?? null,
+      canonicalVendorName: resolution?.canonicalName ?? null,
+      officialDomains: resolution?.officialDomains ?? [],
+      outcome: 'failed',
+      cachePath,
+      phaseTimings,
+      memoLength: memo.length,
+      report: null,
+      promotionResult: null,
+      bundleId: null,
+      baselineBundleId: baselineSnapshot?.bundleId ?? null,
+      error: {
+        phase,
+        ...describeError(error)
+      },
+      backgroundRefresh: options.backgroundRefresh,
+      forceRefresh: options.forceRefresh,
+      streamed: Boolean(options.onProgress)
+    }));
     throw error;
   }
 }
@@ -487,6 +588,21 @@ async function tryReuseBaselineReport(
   }
 
   return baselineSnapshot.report;
+}
+
+async function tryStoreResearchRunTrace(
+  runId: string,
+  trace: ReturnType<typeof buildResearchRunTracePayload>
+) {
+  try {
+    await storeResearchRunTrace(trace);
+  } catch (error) {
+    logResearchEvent('cache_write_failed', {
+      runId,
+      cacheLayer: 'research_run_trace',
+      ...describeError(error)
+    });
+  }
 }
 
 export {


### PR DESCRIPTION
## Summary
- persist per-run research trace artifacts for offline shadow grading
- add a DB migration, repository, and inspect CLI for stored research run traces
- record success and failure traces from the research workflow with cache path and timing details

## Validation
- npm run db:migrate
- npm run test:server
- npm run build
- npm run traces:inspect -- --limit 3
- npm run traces:inspect -- --subject Miro --limit 2

Closes #22