### PR TITLE
Add live production metrics for drift and reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The backend serves the built frontend from `dist/` in production mode.
 - current production architecture: [architecture.md](architecture.md)
 - future extensibility design for configurable guardrails: [docs/extensible-guardrail-architecture.md](docs/extensible-guardrail-architecture.md)
 - evaluation strategy for releases and production: [docs/evaluation-plan.md](docs/evaluation-plan.md)
+- production metric definitions and local verification flow: [docs/production-metrics.md](docs/production-metrics.md)
 - eval case schema and validator: [evals/caseSchema.ts](evals/caseSchema.ts), [evals/validateCases.ts](evals/validateCases.ts)
 
 ## Database migrations

--- a/docs/production-metrics.md
+++ b/docs/production-metrics.md
@@ -40,6 +40,7 @@ Use this event for:
 Notes:
 
 - streamed failures still return HTTP `200` after the SSE session is established, so streamed failures are surfaced via `result: "stream_error"` plus `reportedStatus`
+- client disconnects before the final SSE payload are surfaced via `result: "stream_disconnected"` with `reportedStatus: 499`
 - JSON requests expose the actual status code directly in `status`
 
 ### `research_run_summary`

--- a/docs/production-metrics.md
+++ b/docs/production-metrics.md
@@ -1,0 +1,180 @@
+# Production Metrics
+
+This project emits structured metric events to stdout so production log pipelines can derive drift and reliability metrics without adding a separate metrics backend first.
+
+## Metric events
+
+The application emits JSON lines with:
+
+- `scope: "metric"`
+- `event`
+- stable event-specific fields
+
+Current metric events:
+
+### `api_request_summary`
+
+Emitted by the HTTP layer for `/api/chat` and `/api/chat/stream`.
+
+Fields:
+
+- `route`
+- `transport`
+- `method`
+- `status`
+- `reportedStatus`
+- `result`
+- `durationMs`
+- `refresh`
+- `requestedSubjectName`
+- `timeout`
+- `errorClass`
+
+Use this event for:
+
+- request volume
+- 4xx / 5xx rate on JSON requests
+- timeout rate at the HTTP layer
+- request latency
+
+Notes:
+
+- streamed failures still return HTTP `200` after the SSE session is established, so streamed failures are surfaced via `result: "stream_error"` plus `reportedStatus`
+- JSON requests expose the actual status code directly in `status`
+
+### `research_run_summary`
+
+Emitted by the research workflow on:
+
+- accepted-cache hit
+- live success
+- live failure
+
+Fields:
+
+- `runId`
+- `requestedSubjectName`
+- `subjectKey`
+- `canonicalSubjectName`
+- `canonicalVendorName`
+- `outcome`
+- `recommendation`
+- `previousRecommendation`
+- `recommendationChanged`
+- `unknownGuardrails`
+- `unknownGuardrailCount`
+- `acceptedReportCache`
+- `cacheHit`
+- `resolutionSource`
+- `backgroundRefresh`
+- `forceRefresh`
+- `streamed`
+- `timeout`
+- `errorPhase`
+- `errorClass`
+- `errorName`
+- `totalDurationMs`
+- `phaseTimings`
+
+Use this event for:
+
+- cache hit rate
+- background refresh request mix
+- timeout rate inside the research pipeline
+- unknown rate by guardrail
+- recommendation change rate versus the last accepted baseline
+- stage latency distributions
+
+### `background_refresh_event`
+
+Emitted when background refresh work is:
+
+- scheduled
+- skipped
+- completed
+- failed
+
+Fields:
+
+- `runId`
+- `subjectName`
+- `subjectKey`
+- `canonicalName`
+- `state`
+- `reason`
+- `cooldownMs`
+- `elapsedMs`
+- `errorClass`
+
+Use this event for:
+
+- background refresh rate
+- cooldown skip rate
+- refresh failure rate
+
+## Derived metrics
+
+Recommended first metrics:
+
+- request volume:
+  count of `api_request_summary`
+- cache hit rate:
+  count of `research_run_summary.cacheHit = true` divided by non-background-refresh `research_run_summary`
+- background refresh rate:
+  count of `background_refresh_event.state = "scheduled"` divided by non-background-refresh `research_run_summary`
+- timeout rate:
+  count of `research_run_summary.timeout = true` divided by `research_run_summary`
+- 5xx rate:
+  count of `api_request_summary.status >= 500` divided by JSON `api_request_summary`
+- unknown rate:
+  count of `research_run_summary.unknownGuardrailCount > 0` divided by successful `research_run_summary`
+- recommendation change rate:
+  count of `research_run_summary.recommendationChanged = true` divided by successful runs with non-null `previousRecommendation`
+- latency by stage:
+  percentiles over `research_run_summary.phaseTimings`
+
+## Local verification
+
+1. Start the backend:
+
+```bash
+npm run dev:server
+```
+
+2. Trigger a successful live request:
+
+```bash
+curl -s http://localhost:8787/api/chat \
+  -H 'content-type: application/json' \
+  -d '{"companyName":"Miro"}' > /dev/null
+```
+
+3. Trigger a cache-hit path by repeating the same request:
+
+```bash
+curl -s http://localhost:8787/api/chat \
+  -H 'content-type: application/json' \
+  -d '{"companyName":"Miro"}' > /dev/null
+```
+
+4. Trigger a failure path:
+
+```bash
+curl -s http://localhost:8787/api/chat \
+  -H 'content-type: application/json' \
+  -d '{"companyName":"a"}'
+```
+
+5. Inspect the backend logs for metric events:
+
+- `event: "api_request_summary"`
+- `event: "research_run_summary"`
+- `event: "background_refresh_event"`
+
+6. For local semantic verification without live research, run the offline shadow-grading fixture:
+
+```bash
+npm run evals:run-production-shadow-grading -- --input-file evals/cases/_fixtures/shadow-traces.sample.jsonl
+```
+
+This writes JSON and Markdown outputs under `evals/reports/`.

--- a/server/app.ts
+++ b/server/app.ts
@@ -14,6 +14,8 @@ import {
 import { formatResearchError } from './formatResearchError.js';
 import { createSecurityHeadersMiddleware } from './securityHeaders.js';
 import { researchCompany } from './researchAgent.js';
+import { describeError, logMetricEvent } from './research/logging.js';
+import { buildApiRequestMetricPayload } from './research/metrics.js';
 import type {
   ResearchProgressUpdate,
   ResearchRequest,
@@ -27,6 +29,7 @@ type CreateEnterpriseAppOptions = {
   checkDatabaseHealthFn?: typeof checkDatabaseHealth;
   createMockReportFn?: typeof createMockReport;
   researchCompanyFn?: typeof researchCompany;
+  logMetricFn?: typeof logMetricEvent;
   distDir?: string;
   serveStatic?: boolean;
 };
@@ -41,6 +44,7 @@ export function createEnterpriseApp(
     checkDatabaseHealthFn = checkDatabaseHealth,
     createMockReportFn = createMockReport,
     researchCompanyFn = researchCompany,
+    logMetricFn = logMetricEvent,
     distDir = getDefaultDistDir(),
     serveStatic = true
   }: CreateEnterpriseAppOptions = {}
@@ -108,9 +112,26 @@ export function createEnterpriseApp(
   });
 
   app.post('/api/chat', async (req, res) => {
-    const researchTarget = requireResearchTarget(req, res);
+    const researchTarget = getResearchRequestData(req);
+    const startedAt = Date.now();
 
-    if (!researchTarget) {
+    if (researchTarget.companyName.length < 2) {
+      res.status(400).json({
+        error: 'Enter a company or product name to research.'
+      });
+      logMetricFn(
+        'api_request_summary',
+        buildApiRequestMetricPayload({
+          route: '/api/chat',
+          transport: 'json',
+          status: 400,
+          result: 'client_error',
+          durationMs: Date.now() - startedAt,
+          refresh: researchTarget.refresh,
+          requestedSubjectName: researchTarget.companyName,
+          errorClass: 'InvalidVendorInputError'
+        })
+      );
       return;
     }
 
@@ -121,8 +142,21 @@ export function createEnterpriseApp(
       const response: ResearchResponse = { mode: 'live', report };
 
       res.json(response);
+      logMetricFn(
+        'api_request_summary',
+        buildApiRequestMetricPayload({
+          route: '/api/chat',
+          transport: 'json',
+          status: 200,
+          result: 'success',
+          durationMs: Date.now() - startedAt,
+          refresh: researchTarget.refresh,
+          requestedSubjectName: researchTarget.companyName
+        })
+      );
     } catch (error) {
       const { message, status } = formatResearchError(error);
+      const errorDetails = describeError(error);
 
       if (status === 500) {
         console.error(error);
@@ -131,13 +165,44 @@ export function createEnterpriseApp(
       res.status(status).json({
         error: message
       });
+      logMetricFn(
+        'api_request_summary',
+        buildApiRequestMetricPayload({
+          route: '/api/chat',
+          transport: 'json',
+          status,
+          result: status >= 500 ? 'server_error' : 'client_error',
+          durationMs: Date.now() - startedAt,
+          refresh: researchTarget.refresh,
+          requestedSubjectName: researchTarget.companyName,
+          timeout: errorDetails.errorClass === 'ResearchTimeoutError',
+          errorClass: errorDetails.errorClass
+        })
+      );
     }
   });
 
   app.post('/api/chat/stream', async (req, res) => {
-    const researchTarget = requireResearchTarget(req, res);
+    const researchTarget = getResearchRequestData(req);
+    const startedAt = Date.now();
 
-    if (!researchTarget) {
+    if (researchTarget.companyName.length < 2) {
+      res.status(400).json({
+        error: 'Enter a company or product name to research.'
+      });
+      logMetricFn(
+        'api_request_summary',
+        buildApiRequestMetricPayload({
+          route: '/api/chat/stream',
+          transport: 'sse',
+          status: 400,
+          result: 'client_error',
+          durationMs: Date.now() - startedAt,
+          refresh: researchTarget.refresh,
+          requestedSubjectName: researchTarget.companyName,
+          errorClass: 'InvalidVendorInputError'
+        })
+      );
       return;
     }
 
@@ -176,8 +241,21 @@ export function createEnterpriseApp(
         mode: 'live',
         report
       });
+      logMetricFn(
+        'api_request_summary',
+        buildApiRequestMetricPayload({
+          route: '/api/chat/stream',
+          transport: 'sse',
+          status: 200,
+          result: 'success',
+          durationMs: Date.now() - startedAt,
+          refresh: researchTarget.refresh,
+          requestedSubjectName: researchTarget.companyName
+        })
+      );
     } catch (error) {
       const { message, status } = formatResearchError(error);
+      const errorDetails = describeError(error);
 
       if (status === 500) {
         console.error(error);
@@ -186,6 +264,21 @@ export function createEnterpriseApp(
       sendEvent('error', {
         error: message
       });
+      logMetricFn(
+        'api_request_summary',
+        buildApiRequestMetricPayload({
+          route: '/api/chat/stream',
+          transport: 'sse',
+          status: 200,
+          reportedStatus: status,
+          result: 'stream_error',
+          durationMs: Date.now() - startedAt,
+          refresh: researchTarget.refresh,
+          requestedSubjectName: researchTarget.companyName,
+          timeout: errorDetails.errorClass === 'ResearchTimeoutError',
+          errorClass: errorDetails.errorClass
+        })
+      );
     } finally {
       if (!res.writableEnded) {
         res.end();
@@ -225,18 +318,4 @@ function getResearchRequestData(req: express.Request) {
     companyName: typeof companyName === 'string' ? companyName.trim() : '',
     refresh: refresh === true
   };
-}
-
-function requireResearchTarget(req: express.Request, res: express.Response) {
-  const normalizedRequest = getResearchRequestData(req);
-
-  if (normalizedRequest.companyName.length >= 2) {
-    return normalizedRequest;
-  }
-
-  res.status(400).json({
-    error: 'Enter a company or product name to research.'
-  });
-
-  return null;
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -220,11 +220,12 @@ export function createEnterpriseApp(
 
     const sendEvent = (event: string, payload: unknown) => {
       if (closed || res.writableEnded) {
-        return;
+        return false;
       }
 
       res.write(`event: ${event}\n`);
       res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      return true;
     };
 
     sendEvent('ready', { ok: true });
@@ -237,7 +238,7 @@ export function createEnterpriseApp(
         }
       });
 
-      sendEvent('result', {
+      const delivered = sendEvent('result', {
         mode: 'live',
         report
       });
@@ -247,10 +248,12 @@ export function createEnterpriseApp(
           route: '/api/chat/stream',
           transport: 'sse',
           status: 200,
-          result: 'success',
+          reportedStatus: delivered ? null : 499,
+          result: delivered ? 'success' : 'stream_disconnected',
           durationMs: Date.now() - startedAt,
           refresh: researchTarget.refresh,
-          requestedSubjectName: researchTarget.companyName
+          requestedSubjectName: researchTarget.companyName,
+          errorClass: delivered ? null : 'ClientDisconnected'
         })
       );
     } catch (error) {
@@ -261,7 +264,7 @@ export function createEnterpriseApp(
         console.error(error);
       }
 
-      sendEvent('error', {
+      const delivered = sendEvent('error', {
         error: message
       });
       logMetricFn(
@@ -270,13 +273,13 @@ export function createEnterpriseApp(
           route: '/api/chat/stream',
           transport: 'sse',
           status: 200,
-          reportedStatus: status,
-          result: 'stream_error',
+          reportedStatus: delivered ? status : 499,
+          result: delivered ? 'stream_error' : 'stream_disconnected',
           durationMs: Date.now() - startedAt,
           refresh: researchTarget.refresh,
           requestedSubjectName: researchTarget.companyName,
-          timeout: errorDetails.errorClass === 'ResearchTimeoutError',
-          errorClass: errorDetails.errorClass
+          timeout: delivered && errorDetails.errorClass === 'ResearchTimeoutError',
+          errorClass: delivered ? errorDetails.errorClass : 'ClientDisconnected'
         })
       );
     } finally {

--- a/server/appMetrics.test.ts
+++ b/server/appMetrics.test.ts
@@ -124,6 +124,128 @@ test('JSON chat route emits server-error API metrics for timeout failures', asyn
   assert.equal(timeoutMetric.fields.timeout, true);
 });
 
+test('SSE chat route emits success metrics when the final result is delivered', async (t) => {
+  const emittedMetrics: CapturedMetric[] = [];
+  const app = createEnterpriseApp({
+    nodeEnv: 'test',
+    serveStatic: false,
+    researchCompanyFn: async (companyName, options) => {
+      options?.onProgress?.({ stage: 'starting', label: 'Starting security review' });
+      return createMockReport(companyName);
+    },
+    logMetricFn: (event, fields) => {
+      emittedMetrics.push({ event, fields });
+    }
+  });
+  const server = app.listen(0);
+
+  t.after(() => {
+    server.close();
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected an ephemeral TCP port for test server.');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const response = await fetch(`${baseUrl}/api/chat/stream`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      companyName: 'Miro'
+    })
+  });
+  const body = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(body, /event: result/);
+
+  const successMetric = emittedMetrics.find(
+    (entry) =>
+      entry.event === 'api_request_summary' &&
+      entry.fields?.route === '/api/chat/stream' &&
+      entry.fields?.result === 'success'
+  );
+
+  assertMetricFields(successMetric);
+  assert.equal(successMetric.fields.transport, 'sse');
+  assert.equal(successMetric.fields.reportedStatus, null);
+});
+
+test('SSE chat route emits disconnect metrics when the client closes before the final result', async (t) => {
+  const emittedMetrics: CapturedMetric[] = [];
+  let resolveResearch: (() => void) | undefined;
+  const researchReleased = new Promise<void>((resolve) => {
+    resolveResearch = resolve;
+  });
+  let resolveDisconnectMetric: (() => void) | undefined;
+  const disconnectMetricSeen = new Promise<void>((resolve) => {
+    resolveDisconnectMetric = resolve;
+  });
+  const app = createEnterpriseApp({
+    nodeEnv: 'test',
+    serveStatic: false,
+    researchCompanyFn: async (companyName, options) => {
+      options?.onProgress?.({ stage: 'starting', label: 'Starting security review' });
+      await researchReleased;
+      return createMockReport(companyName);
+    },
+    logMetricFn: (event, fields) => {
+      emittedMetrics.push({ event, fields });
+
+      if (
+        event === 'api_request_summary' &&
+        fields?.route === '/api/chat/stream' &&
+        fields?.result === 'stream_disconnected'
+      ) {
+        resolveDisconnectMetric?.();
+      }
+    }
+  });
+  const server = app.listen(0);
+
+  t.after(() => {
+    server.close();
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected an ephemeral TCP port for test server.');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const response = await fetch(`${baseUrl}/api/chat/stream`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      companyName: 'Miro'
+    })
+  });
+
+  assert.equal(response.status, 200);
+  await response.body?.cancel();
+  resolveResearch?.();
+  await disconnectMetricSeen;
+
+  const disconnectMetric = emittedMetrics.find(
+    (entry) =>
+      entry.event === 'api_request_summary' &&
+      entry.fields?.route === '/api/chat/stream' &&
+      entry.fields?.result === 'stream_disconnected'
+  );
+
+  assertMetricFields(disconnectMetric);
+  assert.equal(disconnectMetric.fields.reportedStatus, 499);
+  assert.equal(disconnectMetric.fields.errorClass, 'ClientDisconnected');
+});
+
 function assertMetricFields(
   metric: CapturedMetric | undefined
 ): asserts metric is { event: string; fields: Record<string, unknown> } {

--- a/server/appMetrics.test.ts
+++ b/server/appMetrics.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createEnterpriseApp } from './app.js';
+import { createMockReport } from './mockReport.js';
+import { ResearchTimeoutError } from './research/errors.js';
+
+type CapturedMetric = {
+  event: string;
+  fields: Record<string, unknown> | undefined;
+};
+
+test('JSON chat route emits success and invalid-input API metrics', async (t) => {
+  const emittedMetrics: CapturedMetric[] = [];
+  const app = createEnterpriseApp({
+    nodeEnv: 'test',
+    serveStatic: false,
+    researchCompanyFn: async (companyName) => createMockReport(companyName),
+    logMetricFn: (event, fields) => {
+      emittedMetrics.push({ event, fields });
+    }
+  });
+  const server = app.listen(0);
+
+  t.after(() => {
+    server.close();
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected an ephemeral TCP port for test server.');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const successResponse = await fetch(`${baseUrl}/api/chat`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      companyName: 'Miro'
+    })
+  });
+
+  const invalidResponse = await fetch(`${baseUrl}/api/chat`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      companyName: 'a'
+    })
+  });
+
+  assert.equal(successResponse.status, 200);
+  assert.equal(invalidResponse.status, 400);
+
+  const successMetric = emittedMetrics.find(
+    (entry) =>
+      entry.event === 'api_request_summary' &&
+      entry.fields?.route === '/api/chat' &&
+      entry.fields?.result === 'success'
+  );
+  const invalidMetric = emittedMetrics.find(
+    (entry) =>
+      entry.event === 'api_request_summary' &&
+      entry.fields?.route === '/api/chat' &&
+      entry.fields?.status === 400
+  );
+
+  assertMetricFields(successMetric);
+  assert.equal(successMetric.fields.transport, 'json');
+  assertMetricFields(invalidMetric);
+  assert.equal(invalidMetric.fields.result, 'client_error');
+});
+
+test('JSON chat route emits server-error API metrics for timeout failures', async (t) => {
+  const emittedMetrics: CapturedMetric[] = [];
+  const app = createEnterpriseApp({
+    nodeEnv: 'test',
+    serveStatic: false,
+    researchCompanyFn: async () => {
+      throw new ResearchTimeoutError();
+    },
+    logMetricFn: (event, fields) => {
+      emittedMetrics.push({ event, fields });
+    }
+  });
+  const server = app.listen(0);
+
+  t.after(() => {
+    server.close();
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected an ephemeral TCP port for test server.');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const response = await fetch(`${baseUrl}/api/chat`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      companyName: 'Palantir'
+    })
+  });
+
+  assert.equal(response.status, 504);
+
+  const timeoutMetric = emittedMetrics.find(
+    (entry) =>
+      entry.event === 'api_request_summary' &&
+      entry.fields?.route === '/api/chat' &&
+      entry.fields?.status === 504
+  );
+
+  assertMetricFields(timeoutMetric);
+  assert.equal(timeoutMetric.fields.result, 'server_error');
+  assert.equal(timeoutMetric.fields.timeout, true);
+});
+
+function assertMetricFields(
+  metric: CapturedMetric | undefined
+): asserts metric is { event: string; fields: Record<string, unknown> } {
+  assert.ok(metric);
+  assert.ok(metric.fields);
+}

--- a/server/research/logging.ts
+++ b/server/research/logging.ts
@@ -8,10 +8,25 @@ export function logResearchEvent(
   event: string,
   fields: Record<string, unknown> = {}
 ) {
+  logStructuredEvent('research', event, fields);
+}
+
+export function logMetricEvent(
+  metric: string,
+  fields: Record<string, unknown> = {}
+) {
+  logStructuredEvent('metric', metric, fields);
+}
+
+function logStructuredEvent(
+  scope: 'research' | 'metric',
+  event: string,
+  fields: Record<string, unknown> = {}
+) {
   console.log(
     JSON.stringify({
       ts: new Date().toISOString(),
-      scope: 'research',
+      scope,
       event,
       ...fields
     })

--- a/server/research/metrics.test.ts
+++ b/server/research/metrics.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createMockReport } from '../mockReport.js';
+import {
+  buildApiRequestMetricPayload,
+  buildBackgroundRefreshMetricPayload,
+  buildResearchRunMetricPayload
+} from './metrics.js';
+
+test('buildResearchRunMetricPayload captures cache hits, unknowns, and recommendation drift', () => {
+  const report = createMockReport('Miro');
+  report.recommendation = 'green';
+  report.guardrails.euDataResidency.status = 'unknown';
+
+  const metric = buildResearchRunMetricPayload({
+    runId: 'abc12345',
+    requestedSubjectName: 'Miro',
+    subjectKey: 'miro',
+    canonicalSubjectName: 'Miro',
+    canonicalVendorName: 'Miro',
+    outcome: 'succeeded',
+    report,
+    previousRecommendation: 'yellow',
+    phaseTimings: {
+      resolutionCompletedMs: 400,
+      memoGeneratedMs: 3200,
+      completedMs: 5100
+    },
+    cachePath: {
+      acceptedReportCache: 'hit',
+      resolutionSource: 'cache'
+    }
+  });
+
+  assert.equal(metric.cacheHit, true);
+  assert.equal(metric.recommendationChanged, true);
+  assert.equal(metric.totalDurationMs, 5100);
+  assert.deepEqual(metric.unknownGuardrails, ['euDataResidency']);
+  assert.equal(metric.unknownGuardrailCount, 1);
+  assert.equal(metric.timeout, false);
+});
+
+test('buildResearchRunMetricPayload marks timeout failures', () => {
+  const metric = buildResearchRunMetricPayload({
+    runId: 'def67890',
+    requestedSubjectName: 'Palantir',
+    outcome: 'failed',
+    previousRecommendation: 'yellow',
+    phaseTimings: {
+      failedMs: 180000
+    },
+    cachePath: {
+      acceptedReportCache: 'miss'
+    },
+    error: {
+      phase: 'decision',
+      errorClass: 'ResearchTimeoutError',
+      errorName: 'ResearchTimeoutError'
+    }
+  });
+
+  assert.equal(metric.timeout, true);
+  assert.equal(metric.totalDurationMs, 180000);
+  assert.equal(metric.errorPhase, 'decision');
+});
+
+test('buildBackgroundRefreshMetricPayload normalizes refresh metric fields', () => {
+  const metric = buildBackgroundRefreshMetricPayload({
+    runId: 'run12345',
+    subjectName: 'Grammarly',
+    subjectKey: 'grammarly',
+    canonicalName: 'Grammarly',
+    state: 'skipped',
+    reason: 'cooldown_active',
+    cooldownMs: 600000
+  });
+
+  assert.equal(metric.state, 'skipped');
+  assert.equal(metric.reason, 'cooldown_active');
+  assert.equal(metric.cooldownMs, 600000);
+});
+
+test('buildApiRequestMetricPayload captures status and timeout fields', () => {
+  const metric = buildApiRequestMetricPayload({
+    route: '/api/chat',
+    transport: 'json',
+    status: 504,
+    result: 'server_error',
+    durationMs: 90000,
+    refresh: true,
+    requestedSubjectName: 'Databricks',
+    timeout: true,
+    errorClass: 'ResearchTimeoutError'
+  });
+
+  assert.equal(metric.status, 504);
+  assert.equal(metric.timeout, true);
+  assert.equal(metric.result, 'server_error');
+  assert.equal(metric.requestedSubjectName, 'Databricks');
+});

--- a/server/research/metrics.ts
+++ b/server/research/metrics.ts
@@ -85,7 +85,12 @@ export function buildApiRequestMetricPayload(input: {
   transport: 'json' | 'sse';
   method?: string;
   status: number;
-  result: 'success' | 'client_error' | 'server_error' | 'stream_error';
+  result:
+    | 'success'
+    | 'client_error'
+    | 'server_error'
+    | 'stream_error'
+    | 'stream_disconnected';
   durationMs: number;
   refresh: boolean;
   requestedSubjectName?: string;

--- a/server/research/metrics.ts
+++ b/server/research/metrics.ts
@@ -1,0 +1,147 @@
+import type { EnterpriseReadinessReport } from '../../shared/contracts.js';
+
+export function buildResearchRunMetricPayload(input: {
+  runId: string;
+  requestedSubjectName: string;
+  subjectKey?: string | null;
+  canonicalSubjectName?: string | null;
+  canonicalVendorName?: string | null;
+  outcome: 'succeeded' | 'failed';
+  report?: EnterpriseReadinessReport | null;
+  previousRecommendation?: string | null;
+  phaseTimings?: Record<string, number>;
+  cachePath?: Record<string, unknown>;
+  error?: {
+    phase?: string | null;
+    errorClass?: string | null;
+    errorName?: string | null;
+  } | null;
+  backgroundRefresh?: boolean;
+  forceRefresh?: boolean;
+  streamed?: boolean;
+}) {
+  const report = input.report ?? null;
+  const previousRecommendation = input.previousRecommendation ?? null;
+  const currentRecommendation = report?.recommendation ?? null;
+  const unknownGuardrails = collectUnknownGuardrails(report);
+  const totalDurationMs = deriveTotalDurationMs(input.phaseTimings ?? {});
+  const acceptedReportCache = normalizeStringField(input.cachePath?.acceptedReportCache);
+  const resolutionSource = normalizeStringField(input.cachePath?.resolutionSource);
+
+  return {
+    runId: input.runId,
+    requestedSubjectName: input.requestedSubjectName,
+    subjectKey: input.subjectKey ?? null,
+    canonicalSubjectName: input.canonicalSubjectName ?? report?.companyName ?? null,
+    canonicalVendorName: input.canonicalVendorName ?? null,
+    outcome: input.outcome,
+    recommendation: currentRecommendation,
+    previousRecommendation,
+    recommendationChanged:
+      Boolean(previousRecommendation) && previousRecommendation !== currentRecommendation,
+    unknownGuardrails,
+    unknownGuardrailCount: unknownGuardrails.length,
+    acceptedReportCache,
+    cacheHit: acceptedReportCache === 'hit',
+    resolutionSource,
+    backgroundRefresh: Boolean(input.backgroundRefresh),
+    forceRefresh: Boolean(input.forceRefresh),
+    streamed: Boolean(input.streamed),
+    timeout: input.error?.errorClass === 'ResearchTimeoutError',
+    errorPhase: input.error?.phase ?? null,
+    errorClass: input.error?.errorClass ?? null,
+    errorName: input.error?.errorName ?? null,
+    totalDurationMs,
+    phaseTimings: input.phaseTimings ?? {}
+  };
+}
+
+export function buildBackgroundRefreshMetricPayload(input: {
+  runId: string;
+  subjectName: string;
+  subjectKey: string;
+  canonicalName: string;
+  state: 'scheduled' | 'completed' | 'failed' | 'skipped';
+  reason?: string | null;
+  cooldownMs?: number | null;
+  elapsedMs?: number | null;
+  errorClass?: string | null;
+}) {
+  return {
+    runId: input.runId,
+    subjectName: input.subjectName,
+    subjectKey: input.subjectKey,
+    canonicalName: input.canonicalName,
+    state: input.state,
+    reason: input.reason ?? null,
+    cooldownMs: input.cooldownMs ?? null,
+    elapsedMs: input.elapsedMs ?? null,
+    errorClass: input.errorClass ?? null
+  };
+}
+
+export function buildApiRequestMetricPayload(input: {
+  route: '/api/chat' | '/api/chat/stream';
+  transport: 'json' | 'sse';
+  method?: string;
+  status: number;
+  result: 'success' | 'client_error' | 'server_error' | 'stream_error';
+  durationMs: number;
+  refresh: boolean;
+  requestedSubjectName?: string;
+  timeout?: boolean;
+  reportedStatus?: number | null;
+  errorClass?: string | null;
+}) {
+  return {
+    route: input.route,
+    transport: input.transport,
+    method: input.method ?? 'POST',
+    status: input.status,
+    reportedStatus: input.reportedStatus ?? null,
+    result: input.result,
+    durationMs: input.durationMs,
+    refresh: input.refresh,
+    requestedSubjectName: input.requestedSubjectName?.trim() || null,
+    timeout: Boolean(input.timeout),
+    errorClass: input.errorClass ?? null
+  };
+}
+
+function collectUnknownGuardrails(report: EnterpriseReadinessReport | null) {
+  if (!report) {
+    return [];
+  }
+
+  const unknowns: string[] = [];
+
+  if (report.guardrails.euDataResidency.status === 'unknown') {
+    unknowns.push('euDataResidency');
+  }
+
+  if (report.guardrails.enterpriseDeployment.status === 'unknown') {
+    unknowns.push('enterpriseDeployment');
+  }
+
+  return unknowns;
+}
+
+function deriveTotalDurationMs(phaseTimings: Record<string, number>) {
+  const explicit =
+    phaseTimings.completedMs ??
+    phaseTimings.failedMs ??
+    phaseTimings.reportPresentedMs ??
+    phaseTimings.decisionBuiltMs ??
+    phaseTimings.memoGeneratedMs ??
+    phaseTimings.resolutionCompletedMs;
+
+  if (Number.isFinite(explicit)) {
+    return explicit;
+  }
+
+  return 0;
+}
+
+function normalizeStringField(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value : null;
+}

--- a/server/researchAgent.ts
+++ b/server/researchAgent.ts
@@ -21,6 +21,7 @@ import { evaluateCandidateReport } from './research/cachePolicy.js';
 import {
   createResearchRunId,
   describeError,
+  logMetricEvent,
   logResearchEvent,
   summarizeInputForLog
 } from './research/logging.js';
@@ -36,6 +37,10 @@ import {
 } from './db/researchCacheRepository.js';
 import { storeResearchRunTrace } from './db/researchRunTraceRepository.js';
 import { buildResearchRunTracePayload } from './research/traceArtifacts.js';
+import {
+  buildBackgroundRefreshMetricPayload,
+  buildResearchRunMetricPayload
+} from './research/metrics.js';
 type ResearchProgressListener = (update: ResearchProgressUpdate) => void;
 type ResearchWorkflowOptions = {
   onProgress?: ResearchProgressListener;
@@ -202,6 +207,24 @@ async function runResearchWorkflow(
         forceRefresh: options.forceRefresh,
         streamed: Boolean(options.onProgress)
       }));
+      logMetricEvent(
+        'research_run_summary',
+        buildResearchRunMetricPayload({
+          runId,
+          requestedSubjectName: companyName,
+          subjectKey: acceptedSubjectKey,
+          canonicalSubjectName: cachedReport.report.companyName,
+          canonicalVendorName: resolution.canonicalName,
+          outcome: 'succeeded',
+          report: cachedReport.report,
+          previousRecommendation: cachedReport.report.recommendation,
+          phaseTimings,
+          cachePath,
+          backgroundRefresh: options.backgroundRefresh,
+          forceRefresh: options.forceRefresh,
+          streamed: Boolean(options.onProgress)
+        })
+      );
 
       return cachedReport.report;
     }
@@ -331,6 +354,24 @@ async function runResearchWorkflow(
       forceRefresh: options.forceRefresh,
       streamed: Boolean(options.onProgress)
     }));
+    logMetricEvent(
+      'research_run_summary',
+      buildResearchRunMetricPayload({
+        runId,
+        requestedSubjectName: companyName,
+        subjectKey: acceptedSubjectKey,
+        canonicalSubjectName: report.companyName,
+        canonicalVendorName: resolution.canonicalName,
+        outcome: 'succeeded',
+        report,
+        previousRecommendation: baselineSnapshot?.report.recommendation ?? null,
+        phaseTimings,
+        cachePath,
+        backgroundRefresh: options.backgroundRefresh,
+        forceRefresh: options.forceRefresh,
+        streamed: Boolean(options.onProgress)
+      })
+    );
 
     return report;
   } catch (error) {
@@ -378,6 +419,30 @@ async function runResearchWorkflow(
       forceRefresh: options.forceRefresh,
       streamed: Boolean(options.onProgress)
     }));
+    logMetricEvent(
+      'research_run_summary',
+      buildResearchRunMetricPayload({
+        runId,
+        requestedSubjectName:
+          phase === 'intake'
+            ? rawCompanyName.trim() || inputSummary.preview
+            : companyName,
+        subjectKey: acceptedSubjectKey || null,
+        canonicalSubjectName: decision?.companyName ?? null,
+        canonicalVendorName: resolution?.canonicalName ?? null,
+        outcome: 'failed',
+        previousRecommendation: baselineSnapshot?.report.recommendation ?? null,
+        phaseTimings,
+        cachePath,
+        error: {
+          phase,
+          ...describeError(error)
+        },
+        backgroundRefresh: options.backgroundRefresh,
+        forceRefresh: options.forceRefresh,
+        streamed: Boolean(options.onProgress)
+      })
+    );
     throw error;
   }
 }
@@ -401,6 +466,17 @@ function maybeStartBackgroundRefresh(
       subjectKey,
       reason: 'already_running'
     });
+    logMetricEvent(
+      'background_refresh_event',
+      buildBackgroundRefreshMetricPayload({
+        runId,
+        subjectName: requestedSubjectName,
+        subjectKey,
+        canonicalName: resolution.canonicalName,
+        state: 'skipped',
+        reason: 'already_running'
+      })
+    );
     return;
   }
 
@@ -413,6 +489,18 @@ function maybeStartBackgroundRefresh(
       reason: 'cooldown_active',
       cooldownMs
     });
+    logMetricEvent(
+      'background_refresh_event',
+      buildBackgroundRefreshMetricPayload({
+        runId,
+        subjectName: requestedSubjectName,
+        subjectKey,
+        canonicalName: resolution.canonicalName,
+        state: 'skipped',
+        reason: 'cooldown_active',
+        cooldownMs
+      })
+    );
     return;
   }
 
@@ -427,6 +515,16 @@ function maybeStartBackgroundRefresh(
     bundleId: cachedReport?.bundleId,
     cachedAt: cachedReport?.fetchedAt
   });
+  logMetricEvent(
+    'background_refresh_event',
+    buildBackgroundRefreshMetricPayload({
+      runId,
+      subjectName: requestedSubjectName,
+      subjectKey,
+      canonicalName: resolution.canonicalName,
+      state: 'scheduled'
+    })
+  );
 
   setTimeout(() => {
     void runResearchWorkflow(requestedSubjectName, {
@@ -442,15 +540,37 @@ function maybeStartBackgroundRefresh(
           subjectKey,
           recommendation: report.recommendation
         });
+        logMetricEvent(
+          'background_refresh_event',
+          buildBackgroundRefreshMetricPayload({
+            runId,
+            subjectName: requestedSubjectName,
+            subjectKey,
+            canonicalName: report.companyName,
+            state: 'completed'
+          })
+        );
       })
       .catch((error) => {
+        const errorDetails = describeError(error);
         logResearchEvent('background_refresh_failed', {
           runId,
           subjectName: requestedSubjectName,
           canonicalName: resolution.canonicalName,
           subjectKey,
-          ...describeError(error)
+          ...errorDetails
         });
+        logMetricEvent(
+          'background_refresh_event',
+          buildBackgroundRefreshMetricPayload({
+            runId,
+            subjectName: requestedSubjectName,
+            subjectKey,
+            canonicalName: resolution.canonicalName,
+            state: 'failed',
+            errorClass: errorDetails.errorClass
+          })
+        );
       })
       .finally(() => {
         activeBackgroundRefreshes.delete(subjectKey);


### PR DESCRIPTION
## Summary
- add explicit metric event emission for API requests, research runs, and background refreshes
- define the production metric set and local verification flow in `docs/production-metrics.md`
- add server tests for metric payload builders and HTTP metric emission

## Validation
- npm run test:server
- npm run build
- manual local verification on the real app with success, cache-hit, and invalid-input requests
  - confirmed `api_request_summary`
  - confirmed `research_run_summary`
  - confirmed `background_refresh_event`

Closes #24