### PR TITLE
Surface live research activity updates

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import { researchCompany } from './researchAgent.js';
 import { describeError, logMetricEvent } from './research/logging.js';
 import { buildApiRequestMetricPayload } from './research/metrics.js';
 import type {
+  ResearchActivityUpdate,
   ResearchProgressUpdate,
   ResearchRequest,
   ResearchResponse
@@ -233,6 +234,9 @@ export function createEnterpriseApp(
     try {
       const report = await researchCompanyFn(researchTarget.companyName, {
         forceRefresh: researchTarget.refresh,
+        onActivity: (update: ResearchActivityUpdate) => {
+          sendEvent('activity', update);
+        },
         onProgress: (update: ResearchProgressUpdate) => {
           sendEvent('progress', update);
         }

--- a/server/research/retrieval.test.ts
+++ b/server/research/retrieval.test.ts
@@ -15,6 +15,7 @@ const resolution: VendorResolution = {
 
 test('generateResearchMemo assembles streamed text and emits ordered progress stages', async () => {
   const seenStages: string[] = [];
+  const seenActivities: string[] = [];
   const diagnostics: string[] = [];
 
   const memo = await generateResearchMemo(
@@ -26,7 +27,16 @@ test('generateResearchMemo assembles streamed text and emits ordered progress st
     async (_, __, options) => {
       assert.equal(options.maxTurns, 4);
       return createStreamResult([
-        runItemEvent('tool_called'),
+        runItemEvent('tool_called', {
+          type: 'hosted_tool_call',
+          name: 'web_search',
+          arguments: JSON.stringify({ query: 'Grammarly EU residency' })
+        }),
+        runItemEvent('tool_output', {
+          type: 'hosted_tool_call',
+          name: 'web_search',
+          output: 'Top result: https://support.grammarly.com/hc/en-us/articles/example'
+        }),
         textDeltaEvent('Vendor: Grammarly. EU data residency: Enterprise customers can select EU. '),
         textDeltaEvent(
           'Enterprise deployment: Supports SAML SSO and SCIM. Preliminary verdict: Yellow.'
@@ -34,6 +44,7 @@ test('generateResearchMemo assembles streamed text and emits ordered progress st
       ]);
     },
     {
+      onActivity: (update) => seenActivities.push(update.label),
       onDiagnostic: (event) => diagnostics.push(event.event)
     }
   );
@@ -47,10 +58,21 @@ test('generateResearchMemo assembles streamed text and emits ordered progress st
     'synthesizing',
     'finalizing'
   ]);
+  assert.deepEqual(seenActivities, [
+    'Running search pass 1 across official vendor docs',
+    'Searching official documentation on grammarly.com, support.grammarly.com',
+    'Waiting for source matches from grammarly.com, support.grammarly.com',
+    'Searching vendor documentation for “Grammarly EU residency”',
+    'Reviewing retrieved source from support.grammarly.com',
+    'Checking retrieved evidence for EU residency signals',
+    'Checking retrieved evidence for enterprise deployment controls',
+    'Synthesizing the analyst verdict from the gathered evidence'
+  ]);
   assert.deepEqual(diagnostics, [
     'attempt_started',
     'first_stream_event',
     'tool_called',
+    'tool_output',
     'first_text_delta',
     'stream_completed'
   ]);
@@ -96,6 +118,49 @@ test('generateResearchMemo salvages partial memo on retryable stream error', asy
   assert.match(memo, /EU data residency: No evidence of EU-only residency\./);
 });
 
+test('generateResearchMemo emits retry activity when a search pass fails before usable output', async () => {
+  const seenActivities: string[] = [];
+  let calls = 0;
+
+  const memo = await generateResearchMemo(
+    'Palantir',
+    {
+      canonicalName: 'Palantir',
+      officialDomains: ['palantir.com', 'palantirfoundry.com'],
+      confidence: 'high',
+      alternatives: [],
+      rationale: 'Resolved to the analytics vendor.'
+    },
+    Date.now(),
+    30_000,
+    undefined,
+    async () => {
+      calls += 1;
+
+      if (calls === 1) {
+        return createStreamResult([], new Error('Model did not produce a final response!'));
+      }
+
+      return createStreamResult([
+        textDeltaEvent(
+          'Vendor: Palantir. EU data residency: No explicit EU region commitment found. Enterprise deployment: Supports enterprise deployment controls. Preliminary verdict: Red.'
+        )
+      ]);
+    },
+    {
+      onActivity: (update) => seenActivities.push(update.label)
+    }
+  );
+
+  assert.match(memo, /Vendor: Palantir\./);
+  assert.ok(
+    seenActivities.includes(
+      'Retrying the vendor search because the previous pass did not return a usable answer'
+    )
+  );
+  assert.ok(seenActivities.includes('Running search pass 2 across official vendor docs'));
+});
+
 test('generateResearchMemo maps abort-like failures to ResearchTimeoutError', async () => {
   await assert.rejects(
     () =>
@@ -127,10 +192,16 @@ function createStreamResult(events: RunStreamEvent[], error?: unknown) {
   };
 }
 
-function runItemEvent(name: 'tool_called' | 'tool_output') {
+function runItemEvent(
+  name: 'tool_called' | 'tool_output',
+  rawItem?: Record<string, unknown>
+) {
   return {
     type: 'run_item_stream_event',
-    name
+    name,
+    item: {
+      rawItem
+    }
   } as RunStreamEvent;
 }
 

--- a/server/research/retrieval.test.ts
+++ b/server/research/retrieval.test.ts
@@ -161,6 +161,38 @@ test('generateResearchMemo emits retry activity when a search pass fails before 
   assert.ok(seenActivities.includes('Running search pass 2 across official vendor docs'));
 });
 
+test('generateResearchMemo ignores non-string tool outputs when building source-review activity', async () => {
+  const seenActivities: string[] = [];
+
+  const memo = await generateResearchMemo(
+    'Grammarly',
+    resolution,
+    Date.now(),
+    30_000,
+    undefined,
+    async () =>
+      createStreamResult([
+        runItemEvent('tool_output', {
+          type: 'hosted_tool_call',
+          name: 'web_search',
+          output: {
+            type: 'text',
+            text: 'Top result payload'
+          }
+        }),
+        textDeltaEvent(
+          'Vendor: Grammarly. EU data residency: Enterprise customers can select EU. Enterprise deployment: Supports SAML SSO. Preliminary verdict: Yellow.'
+        )
+      ]),
+    {
+      onActivity: (update) => seenActivities.push(update.label)
+    }
+  );
+
+  assert.match(memo, /Vendor: Grammarly\./);
+  assert.ok(seenActivities.includes('Reviewing retrieved vendor evidence'));
+});
+
 test('generateResearchMemo maps abort-like failures to ResearchTimeoutError', async () => {
   await assert.rejects(
     () =>

--- a/server/research/retrieval.ts
+++ b/server/research/retrieval.ts
@@ -5,7 +5,11 @@ import {
   type RunStreamEvent,
   webSearchTool
 } from '@openai/agents';
-import type { ResearchProgressStage, ResearchProgressUpdate } from '../../shared/contracts.js';
+import type {
+  ResearchActivityUpdate,
+  ResearchProgressStage,
+  ResearchProgressUpdate
+} from '../../shared/contracts.js';
 import { liveResearchStages } from '../../shared/contracts.js';
 import type { VendorResolution } from './vendorIntake.js';
 import {
@@ -15,6 +19,7 @@ import {
 } from './errors.js';
 
 type ResearchProgressListener = (update: ResearchProgressUpdate) => void;
+type ResearchActivityListener = (update: ResearchActivityUpdate) => void;
 export type RetrievalDiagnosticEvent =
   | {
       event:
@@ -66,6 +71,7 @@ export async function generateResearchMemo(
   onProgress?: ResearchProgressListener,
   runResearch: ResearchRunFn = run,
   options: {
+    onActivity?: ResearchActivityListener;
     backgroundRefresh?: boolean;
     onDiagnostic?: RetrievalDiagnosticListener;
   } = {}
@@ -73,6 +79,16 @@ export async function generateResearchMemo(
   const progress = createProgressEmitter(onProgress);
   const maxAttempts = 2;
   const onDiagnostic = options.onDiagnostic;
+  const activity = createActivityEmitter(options.onActivity);
+  const publishDiagnostic = (event: RetrievalDiagnosticEvent) => {
+    onDiagnostic?.(event);
+
+    const diagnosticActivity = toActivityFromDiagnosticEvent(event, resolution.officialDomains);
+
+    if (diagnosticActivity) {
+      activity.emit(diagnosticActivity);
+    }
+  };
 
   progress.advance('starting');
 
@@ -87,7 +103,7 @@ export async function generateResearchMemo(
     try {
       const signal = AbortSignal.timeout(remainingMs);
       const attemptNumber = attempt + 1;
-      onDiagnostic?.({
+      publishDiagnostic({
         event: 'attempt_started',
         attempt: attemptNumber,
         elapsedMs: Date.now() - startedAt,
@@ -103,11 +119,15 @@ export async function generateResearchMemo(
       let sawFirstTextDelta = false;
 
       progress.advance('searching');
+      activity.emit({
+        kind: 'search',
+        label: buildDomainSearchLabel(resolution.officialDomains)
+      });
 
       for await (const event of stream) {
         if (!sawFirstStreamEvent) {
           sawFirstStreamEvent = true;
-          onDiagnostic?.({
+          publishDiagnostic({
             event: 'first_stream_event',
             attempt: attemptNumber,
             elapsedMs: Date.now() - startedAt,
@@ -117,7 +137,7 @@ export async function generateResearchMemo(
 
         if (event.type === 'run_item_stream_event') {
           if (event.name === 'tool_called' || event.name === 'tool_output') {
-            onDiagnostic?.({
+            publishDiagnostic({
               event: event.name,
               attempt: attemptNumber,
               elapsedMs: Date.now() - startedAt
@@ -131,22 +151,25 @@ export async function generateResearchMemo(
           event.data.type === 'output_text_delta'
         ) {
           sawFirstTextDelta = true;
-          onDiagnostic?.({
+          publishDiagnostic({
             event: 'first_text_delta',
             attempt: attemptNumber,
             elapsedMs: Date.now() - startedAt
           });
         }
 
-        streamedMemoText = updateProgressFromStreamEvent(event, streamedMemoText, (stage) =>
-          progress.advance(stage)
+        streamedMemoText = updateProgressFromStreamEvent(
+          event,
+          streamedMemoText,
+          (stage) => progress.advance(stage),
+          (update) => activity.emit(update)
         );
       }
 
       await stream.completed;
 
       const finalMemo = streamedMemoText.trim();
-      onDiagnostic?.({
+      publishDiagnostic({
         event: 'stream_completed',
         attempt: attemptNumber,
         elapsedMs: Date.now() - startedAt,
@@ -155,7 +178,7 @@ export async function generateResearchMemo(
 
       if (stream.error) {
         if (isAbortError(stream.error)) {
-          onDiagnostic?.({
+          publishDiagnostic({
             event: 'attempt_timed_out',
             attempt: attemptNumber,
             elapsedMs: Date.now() - startedAt
@@ -171,7 +194,7 @@ export async function generateResearchMemo(
           }
 
           if (attempt < maxAttempts - 1) {
-            onDiagnostic?.({
+            publishDiagnostic({
               event: 'retrying_after_error',
               attempt: attemptNumber,
               elapsedMs: Date.now() - startedAt,
@@ -200,7 +223,7 @@ export async function generateResearchMemo(
       return finalMemo;
     } catch (error) {
       if (isAbortError(error)) {
-        onDiagnostic?.({
+        publishDiagnostic({
           event: 'attempt_timed_out',
           attempt: attempt + 1,
           elapsedMs: Date.now() - startedAt
@@ -222,7 +245,7 @@ export async function generateResearchMemo(
       }
 
       if (isRetryableModelError(error) && attempt < maxAttempts - 1) {
-        onDiagnostic?.({
+        publishDiagnostic({
           event: 'retrying_after_error',
           attempt: attempt + 1,
           elapsedMs: Date.now() - startedAt,
@@ -232,7 +255,7 @@ export async function generateResearchMemo(
       }
 
       if (isRetryableModelError(error)) {
-        onDiagnostic?.({
+        publishDiagnostic({
           event: 'attempt_failed',
           attempt: attempt + 1,
           elapsedMs: Date.now() - startedAt,
@@ -241,7 +264,7 @@ export async function generateResearchMemo(
         throw new ResearchGenerationError();
       }
 
-      onDiagnostic?.({
+      publishDiagnostic({
         event: 'attempt_failed',
         attempt: attempt + 1,
         elapsedMs: Date.now() - startedAt,
@@ -359,14 +382,44 @@ function createProgressEmitter(listener?: ResearchProgressListener) {
   };
 }
 
+function createActivityEmitter(listener?: ResearchActivityListener) {
+  let lastLabel = '';
+
+  return {
+    emit(update: ResearchActivityUpdate) {
+      if (!listener || !update.label || update.label === lastLabel) {
+        return;
+      }
+
+      lastLabel = update.label;
+      listener(update);
+    }
+  };
+}
+
 function updateProgressFromStreamEvent(
   event: RunStreamEvent,
   memoText: string,
-  advance: (stage: ResearchProgressStage) => void
+  advance: (stage: ResearchProgressStage) => void,
+  emitActivity: (update: ResearchActivityUpdate) => void
 ) {
   if (event.type === 'run_item_stream_event') {
-    if (event.name === 'tool_called' || event.name === 'tool_output') {
+    if (event.name === 'tool_called') {
       advance('searching');
+      const searchActivity = toSearchActivity(event);
+
+      if (searchActivity) {
+        emitActivity(searchActivity);
+      }
+    }
+
+    if (event.name === 'tool_output') {
+      advance('searching');
+      const sourceReviewActivity = toSourceReviewActivity(event);
+
+      if (sourceReviewActivity) {
+        emitActivity(sourceReviewActivity);
+      }
     }
   }
 
@@ -379,6 +432,10 @@ function updateProgressFromStreamEvent(
 
   if (nextMemoText.trim().length > 40) {
     advance('reviewing_eu');
+    emitActivity({
+      kind: 'evidence',
+      label: 'Checking retrieved evidence for EU residency signals'
+    });
   }
 
   if (
@@ -386,6 +443,10 @@ function updateProgressFromStreamEvent(
     normalized.includes('enterprise controls')
   ) {
     advance('reviewing_deployment');
+    emitActivity({
+      kind: 'evidence',
+      label: 'Checking retrieved evidence for enterprise deployment controls'
+    });
   }
 
   if (
@@ -393,9 +454,167 @@ function updateProgressFromStreamEvent(
     /\bverdict\b/.test(normalized)
   ) {
     advance('synthesizing');
+    emitActivity({
+      kind: 'synthesis',
+      label: 'Synthesizing the analyst verdict from the gathered evidence'
+    });
   }
 
   return nextMemoText;
+}
+
+function buildDomainSearchLabel(officialDomains: string[]) {
+  if (officialDomains.length === 0) {
+    return 'Searching official vendor documentation';
+  }
+
+  if (officialDomains.length === 1) {
+    return `Searching official documentation on ${officialDomains[0]}`;
+  }
+
+  return `Searching official documentation on ${officialDomains.join(', ')}`;
+}
+
+function toActivityFromDiagnosticEvent(
+  event: RetrievalDiagnosticEvent,
+  officialDomains: string[]
+) {
+  switch (event.event) {
+    case 'attempt_started':
+      return {
+        kind: 'search' as const,
+        label: `Running search pass ${event.attempt} across official vendor docs`
+      };
+    case 'first_stream_event':
+      return {
+        kind: 'search' as const,
+        label:
+          officialDomains.length > 0
+            ? `Waiting for source matches from ${officialDomains.join(', ')}`
+            : 'Waiting for usable vendor search results'
+      };
+    case 'retrying_after_error':
+      return {
+        kind: 'search' as const,
+        label: 'Retrying the vendor search because the previous pass did not return a usable answer'
+      };
+    case 'attempt_timed_out':
+      return {
+        kind: 'search' as const,
+        label: 'Vendor search timed out before it produced usable evidence'
+      };
+    case 'attempt_failed':
+      return {
+        kind: 'search' as const,
+        label: `Search pass ${event.attempt} ended without a usable answer`
+      };
+    default:
+      return null;
+  }
+}
+
+function toSearchActivity(event: Extract<RunStreamEvent, { type: 'run_item_stream_event' }>) {
+  const rawItem = event.item.rawItem;
+
+  if (!rawItem || rawItem.type !== 'hosted_tool_call') {
+    return {
+      kind: 'search' as const,
+      label: 'Searching official vendor documentation'
+    };
+  }
+
+  if (!/search/i.test(rawItem.name)) {
+    return null;
+  }
+
+  const query = extractSearchQuery(rawItem.arguments);
+
+  return {
+    kind: 'search' as const,
+    label: query ? `Searching vendor documentation for “${query}”` : 'Searching official vendor documentation'
+  };
+}
+
+function toSourceReviewActivity(event: Extract<RunStreamEvent, { type: 'run_item_stream_event' }>) {
+  const rawItem = event.item.rawItem;
+
+  if (!rawItem) {
+    return {
+      kind: 'source_review' as const,
+      label: 'Reviewing retrieved vendor evidence'
+    };
+  }
+
+  if (rawItem.type === 'hosted_tool_call') {
+    const sourceUrl = extractFirstUrl(rawItem.output);
+
+    if (sourceUrl) {
+      const hostname = safeHostname(sourceUrl);
+
+      return {
+        kind: 'source_review' as const,
+        label: hostname
+          ? `Reviewing retrieved source from ${hostname}`
+          : 'Reviewing a retrieved vendor source'
+      };
+    }
+  }
+
+  if (rawItem.type === 'function_call_result' && rawItem.output.type === 'text') {
+    const sourceUrl = extractFirstUrl(rawItem.output.text);
+
+    if (sourceUrl) {
+      const hostname = safeHostname(sourceUrl);
+
+      return {
+        kind: 'source_review' as const,
+        label: hostname
+          ? `Reviewing retrieved source from ${hostname}`
+          : 'Reviewing a retrieved vendor source'
+      };
+    }
+  }
+
+  return {
+    kind: 'source_review' as const,
+    label: 'Reviewing retrieved vendor evidence'
+  };
+}
+
+function extractSearchQuery(rawArguments: string | undefined) {
+  if (!rawArguments) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawArguments) as
+      | { query?: string; q?: string; search_query?: string }
+      | null;
+
+    const query = parsed?.query ?? parsed?.q ?? parsed?.search_query;
+
+    return typeof query === 'string' && query.trim() ? query.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractFirstUrl(rawText: string | undefined) {
+  if (!rawText) {
+    return null;
+  }
+
+  const match = rawText.match(/https?:\/\/[^\s)"'<>]+/i);
+
+  return match?.[0] ?? null;
+}
+
+function safeHostname(rawUrl: string) {
+  try {
+    return new URL(rawUrl).hostname;
+  } catch {
+    return null;
+  }
 }
 function isRetryableModelError(error: unknown) {
   return (

--- a/server/research/retrieval.ts
+++ b/server/research/retrieval.ts
@@ -599,8 +599,8 @@ function extractSearchQuery(rawArguments: string | undefined) {
   }
 }
 
-function extractFirstUrl(rawText: string | undefined) {
-  if (!rawText) {
+function extractFirstUrl(rawText: unknown) {
+  if (typeof rawText !== 'string' || !rawText) {
     return null;
   }
 

--- a/server/researchAgent.ts
+++ b/server/researchAgent.ts
@@ -13,6 +13,7 @@ import {
 } from './research/errors.js';
 import { generateResearchMemo } from './research/retrieval.js';
 import {
+  type ResearchActivityUpdate,
   liveResearchStages,
   type ResearchProgressUpdate
 } from '../shared/contracts.js';
@@ -49,8 +50,10 @@ import {
   markBackgroundRefreshScheduled
 } from './research/backgroundRefreshPolicy.js';
 type ResearchProgressListener = (update: ResearchProgressUpdate) => void;
+type ResearchActivityListener = (update: ResearchActivityUpdate) => void;
 type ResearchWorkflowOptions = {
   onProgress?: ResearchProgressListener;
+  onActivity?: ResearchActivityListener;
   forceRefresh?: boolean;
   skipAcceptedReportCache?: boolean;
   backgroundRefresh?: boolean;
@@ -94,10 +97,12 @@ export async function researchCompany(
   options: {
     forceRefresh?: boolean;
     onProgress?: ResearchProgressListener;
+    onActivity?: ResearchActivityListener;
   } = {}
 ) {
   return runResearchWorkflow(companyName, {
     forceRefresh: options.forceRefresh,
+    onActivity: options.onActivity,
     onProgress: options.onProgress,
     skipAcceptedReportCache: options.forceRefresh
   });
@@ -176,6 +181,13 @@ async function runResearchWorkflow(
     });
     phaseTimings.resolutionCompletedMs = Date.now() - startedAt;
     cachePath.resolutionSource = resolutionSource;
+    options.onActivity?.({
+      kind: 'resolution',
+      label:
+        companyName === resolution.canonicalName
+          ? `Resolved review subject as ${resolution.canonicalName}`
+          : `Resolved ${companyName} under ${resolution.canonicalName}`
+    });
 
     const cachedReport = options.skipAcceptedReportCache
       ? null
@@ -263,6 +275,7 @@ async function runResearchWorkflow(
       options.onProgress,
       undefined,
       {
+        onActivity: options.onActivity,
         backgroundRefresh: options.backgroundRefresh,
         onDiagnostic: (event) => {
           logResearchEvent('retrieval_diagnostic', {

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -9,6 +9,12 @@ export type ResearchProgressStage =
   | 'reviewing_deployment'
   | 'synthesizing'
   | 'finalizing';
+export type ResearchActivityKind =
+  | 'resolution'
+  | 'search'
+  | 'source_review'
+  | 'evidence'
+  | 'synthesis';
 
 export interface EvidenceItem {
   title: string;
@@ -53,6 +59,11 @@ export interface ResearchResponse {
 
 export interface ResearchProgressUpdate {
   stage: ResearchProgressStage;
+  label: string;
+}
+
+export interface ResearchActivityUpdate {
+  kind: ResearchActivityKind;
   label: string;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useState, useTransition, type ReactNode } from 're
 import type {
   EnterpriseReadinessReport,
   GuardrailAssessment,
+  ResearchActivityUpdate,
   ResearchProgressStage,
   ResearchResponse
 } from '../shared/contracts';
@@ -73,6 +74,7 @@ export default function App() {
     useState<ResearchProgressStage | null>(null);
   const [visibleResearchStage, setVisibleResearchStage] =
     useState<ResearchProgressStage | null>(null);
+  const [researchActivities, setResearchActivities] = useState<ResearchActivityUpdate[]>([]);
   const [pendingAssistantMessage, setPendingAssistantMessage] =
     useState<PendingAssistantMessage | null>(null);
   const [, startTransition] = useTransition();
@@ -139,6 +141,7 @@ export default function App() {
     setIsLoading(false);
     setReportedResearchStage(null);
     setVisibleResearchStage(null);
+    setResearchActivities([]);
   }
 
   function handleCreateConversation() {
@@ -204,6 +207,9 @@ export default function App() {
       const payload = isTestMode
         ? await requestResearch('/api/chat/test', nextCompany)
         : await requestStreamedResearch(nextCompany, {
+            onActivity: (update) => {
+              setResearchActivities((current) => appendResearchActivity(current, update));
+            },
             refresh: options.forceRefresh,
             onProgress: (update) => {
               streamedProgressStages.push(update.stage);
@@ -371,6 +377,7 @@ export default function App() {
             {isLoading ? (
               <LoadingMessage
                 activeStage={visibleResearchStage}
+                activities={researchActivities}
                 isTestMode={isTestMode}
               />
             ) : null}
@@ -447,6 +454,7 @@ async function requestResearch(
 async function requestStreamedResearch(
   companyName: string,
   options: {
+    onActivity: (update: ResearchActivityUpdate) => void;
     refresh?: boolean;
     onProgress: (update: ResearchProgressUpdate) => void;
   }
@@ -496,6 +504,10 @@ async function requestStreamedResearch(
           options.onProgress(parsedEvent.data as ResearchProgressUpdate);
         }
 
+        if (parsedEvent.event === 'activity') {
+          options.onActivity(parsedEvent.data as ResearchActivityUpdate);
+        }
+
         if (parsedEvent.event === 'result') {
           finalPayload = parsedEvent.data as ResearchResponse;
         }
@@ -540,16 +552,36 @@ function parseStreamEvent(rawEvent: string) {
   };
 }
 
+function appendResearchActivity(
+  current: ResearchActivityUpdate[],
+  next: ResearchActivityUpdate
+) {
+  if (!next.label) {
+    return current;
+  }
+
+  const lastActivity = current[current.length - 1];
+
+  if (lastActivity && lastActivity.label === next.label) {
+    return current;
+  }
+
+  return [...current, next].slice(-5);
+}
+
 function LoadingMessage({
   activeStage,
+  activities,
   isTestMode
 }: {
   activeStage: ResearchProgressStage | null;
+  activities: ResearchActivityUpdate[];
   isTestMode: boolean;
 }) {
   const currentStage =
     liveResearchStages.find((stage) => stage.stage === activeStage) ??
     liveResearchStages[0];
+  const latestActivity = activities[activities.length - 1];
   const activeIndex = isTestMode
     ? -1
     : liveResearchStages.findIndex((stage) => stage.stage === currentStage.stage);
@@ -558,7 +590,9 @@ function LoadingMessage({
     <div className="message assistant progress-message">
       <div className="message-meta">agent</div>
       <p className="message-copy">
-        {isTestMode ? 'Loading mocked security review.' : currentStage.label}
+        {isTestMode
+          ? 'Loading mocked security review.'
+          : latestActivity?.label ?? currentStage.label}
       </p>
 
       <div className="typing-indicator" aria-label="Research in progress">
@@ -568,23 +602,38 @@ function LoadingMessage({
       </div>
 
       {!isTestMode ? (
-        <ol className="progress-list">
-          {liveResearchStages.map((stage, index) => {
-            const state =
-              index < activeIndex
-                ? 'done'
-                : index === activeIndex
-                  ? 'active'
-                  : 'pending';
+        <>
+          <ol className="progress-list">
+            {liveResearchStages.map((stage, index) => {
+              const state =
+                index < activeIndex
+                  ? 'done'
+                  : index === activeIndex
+                    ? 'active'
+                    : 'pending';
 
-            return (
-              <li className={`progress-step ${state}`} key={stage.stage}>
-                <span className="progress-marker" aria-hidden="true" />
-                <span>{stage.label}</span>
-              </li>
-            );
-          })}
-        </ol>
+              return (
+                <li className={`progress-step ${state}`} key={stage.stage}>
+                  <span className="progress-marker" aria-hidden="true" />
+                  <span>{stage.label}</span>
+                </li>
+              );
+            })}
+          </ol>
+
+          {activities.length > 0 ? (
+            <div className="progress-activity">
+              <p className="progress-activity-label">Live activity</p>
+              <ol className="progress-activity-list">
+                {activities.map((activity, index) => (
+                  <li className="progress-activity-item" key={`${activity.kind}-${index}`}>
+                    {activity.label}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          ) : null}
+        </>
       ) : null}
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -378,6 +378,34 @@ input {
   background: rgba(77, 208, 166, 0.92);
 }
 
+.progress-activity {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid rgba(188, 216, 255, 0.08);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.progress-activity-label {
+  margin: 0;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(200, 221, 244, 0.62);
+}
+
+.progress-activity-list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0 0 0 1.1rem;
+  color: rgba(235, 243, 252, 0.9);
+}
+
+.progress-activity-item {
+  line-height: 1.45;
+}
+
 .report {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- add additive live `activity` stream events alongside the existing progress stages
- derive user-safe activity updates from retrieval stream events and diagnostics
- render a compact live activity timeline in the loading UI

## Why
The current UI only shows coarse stages like `Searching vendor documentation`, which leaves long or flaky runs feeling stalled. This change keeps the existing stage model but surfaces what the agent is actually doing in analyst-readable language.

## Testing
- npm run test:server
- npm run build
- local SSE replay for `POST /api/chat/stream` confirming `activity` events

Closes #41
